### PR TITLE
feat(merge): thread workstreamId from spec-meta → activate SSOT

### DIFF
--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -164,7 +164,7 @@ export async function mergeCommand(opts: MergeOptions): Promise<void> {
 	}
 	const targetBranch = into ?? sessionBranch ?? config.project.canonicalBranch;
 	const queuePath = join(config.project.root, ".overstory", "merge-queue.db");
-	const queue = createMergeQueue(queuePath);
+	const queue = createMergeQueue(queuePath, config.project.root);
 	const mulchClient = createMulchClient(config.project.root);
 	const resolver = createMergeResolver({
 		aiResolveEnabled: config.merge.aiResolveEnabled,
@@ -260,11 +260,23 @@ async function handleBranch(
 		const taskId = parseTaskId(branchName);
 		const filesModified = await detectModifiedFiles(repoRoot, canonicalBranch, branchName);
 
+		// Best-effort workstreamId lookup from spec-meta written at dispatch time.
+		// Absent meta is fine — non-mission branches exist and skip SSOT update.
+		let workstreamId: string | null = null;
+		try {
+			const { readSpecMeta } = await import("../missions/spec-meta.ts");
+			const meta = await readSpecMeta(config.project.root, taskId);
+			if (meta?.workstreamId) workstreamId = meta.workstreamId;
+		} catch {
+			// Non-fatal; recordWorkstreamMerge will warn later if workstreamId absent.
+		}
+
 		entry = queue.enqueue({
 			branchName,
 			taskId,
 			agentName,
 			filesModified,
+			workstreamId,
 		});
 	}
 

--- a/src/merge/queue.test.ts
+++ b/src/merge/queue.test.ts
@@ -27,6 +27,7 @@ describe("createMergeQueue", () => {
 			taskId: string;
 			agentName: string;
 			filesModified: string[];
+			workstreamId: string | null;
 		}>,
 	) {
 		return {
@@ -34,6 +35,7 @@ describe("createMergeQueue", () => {
 			taskId: overrides?.taskId ?? "bead-123",
 			agentName: overrides?.agentName ?? "test-agent",
 			filesModified: overrides?.filesModified ?? ["src/test.ts"],
+			workstreamId: overrides?.workstreamId,
 		};
 	}
 
@@ -77,6 +79,24 @@ describe("createMergeQueue", () => {
 			expect(entry.taskId).toBe("bead-xyz");
 			expect(entry.agentName).toBe("builder-1");
 			expect(entry.filesModified).toEqual(["src/a.ts", "src/b.ts"]);
+		});
+
+		test("persists workstreamId round-trip", () => {
+			const queue = createMergeQueue(queuePath);
+			const input = makeInput({
+				branchName: "overstory/ws1/task-1",
+				workstreamId: "ws-1-foundation",
+			});
+
+			const entry = queue.enqueue(input);
+
+			expect(entry.workstreamId).toBe("ws-1-foundation");
+		});
+
+		test("workstreamId defaults to null when not provided", () => {
+			const queue = createMergeQueue(queuePath);
+			const entry = queue.enqueue(makeInput({ branchName: "legacy/branch" }));
+			expect(entry.workstreamId).toBe(null);
 		});
 	});
 

--- a/src/merge/queue.ts
+++ b/src/merge/queue.ts
@@ -7,6 +7,8 @@
  */
 
 import { Database } from "bun:sqlite";
+import { existsSync, readFileSync } from "node:fs";
+import { join as joinPath } from "node:path";
 import {
 	applyMigrations,
 	bootstrapSchemaVersion,
@@ -61,6 +63,7 @@ interface MergeQueueRow {
 	status: string;
 	resolved_tier: string | null;
 	compat_report_path: string | null;
+	workstream_id: string | null;
 }
 
 const CREATE_TABLE = `
@@ -69,6 +72,7 @@ CREATE TABLE IF NOT EXISTS merge_queue (
   branch_name TEXT NOT NULL,
   task_id TEXT NOT NULL,
   mission_id TEXT,
+  workstream_id TEXT,
   agent_name TEXT NOT NULL,
   files_modified TEXT NOT NULL DEFAULT '[]',
   enqueued_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
@@ -78,6 +82,11 @@ CREATE TABLE IF NOT EXISTS merge_queue (
     CHECK(resolved_tier IS NULL OR resolved_tier IN ('clean-merge','auto-resolve','ai-resolve','reimagine')),
   compat_report_path TEXT
 )`;
+
+/** Project root exposed to migration v3 for backfill file reads.
+ * Set immediately before applyMigrations and cleared after. Not thread-safe,
+ * but migration runs synchronously at store creation. */
+let projectRootForMigration: string | null = null;
 
 /** Migrations for merge_queue schema evolution. */
 const MIGRATIONS: Migration[] = [
@@ -108,6 +117,9 @@ const MIGRATIONS: Migration[] = [
 						"compat_report_path",
 					],
 				});
+				// CREATE_TABLE includes mission_id and workstream_id for new installs,
+				// but v1 may run before v2/v3 — those migrations add the columns later
+				// via ALTER TABLE. rebuildTable above preserves only v0 columns.
 			}
 		},
 		detect: (_db, columns) => columns.has("compat_report_path"),
@@ -121,6 +133,47 @@ const MIGRATIONS: Migration[] = [
 			}
 		},
 		detect: (_db, columns) => columns.has("mission_id"),
+	},
+	{
+		version: 3,
+		description: "add workstream_id column; backfill from spec-meta.json for existing rows",
+		up: (db) => {
+			if (!hasColumn(db, "merge_queue", "workstream_id")) {
+				db.exec("ALTER TABLE merge_queue ADD COLUMN workstream_id TEXT");
+			}
+			// Backfill runs only when `projectRoot` was passed to createMergeQueue.
+			// Module-level `projectRootForMigration` is set just before applyMigrations.
+			if (!projectRootForMigration) return;
+			const rows = db
+				.prepare<{ id: number; task_id: string }, []>(
+					"SELECT id, task_id FROM merge_queue WHERE workstream_id IS NULL",
+				)
+				.all();
+			if (rows.length === 0) return;
+			const updateStmt = db.prepare("UPDATE merge_queue SET workstream_id = $wsId WHERE id = $id");
+			for (const row of rows) {
+				try {
+					const metaPath = joinPath(
+						projectRootForMigration,
+						".overstory",
+						"specs",
+						`${row.task_id}.meta.json`,
+					);
+					if (!existsSync(metaPath)) continue; // ENOENT: silent skip (legacy/non-mission)
+					const parsed = JSON.parse(readFileSync(metaPath, "utf-8")) as {
+						workstreamId?: unknown;
+					};
+					if (typeof parsed.workstreamId === "string" && parsed.workstreamId.length > 0) {
+						updateStmt.run({ $id: row.id, $wsId: parsed.workstreamId });
+					}
+				} catch (err) {
+					process.stderr.write(
+						`[merge_queue v3] spec-meta parse failed for ${row.task_id}: ${String(err)}\n`,
+					);
+				}
+			}
+		},
+		detect: (_db, columns) => columns.has("workstream_id"),
 	},
 ];
 
@@ -148,6 +201,7 @@ function rowToEntry(row: MergeQueueRow): MergeEntry {
 		branchName: row.branch_name,
 		taskId: row.task_id,
 		missionId: row.mission_id,
+		workstreamId: row.workstream_id,
 		agentName: row.agent_name,
 		filesModified,
 		enqueuedAt: row.enqueued_at,
@@ -176,8 +230,13 @@ function migrateBeadIdToTaskId(db: Database): void {
  *
  * Initializes the database with WAL mode and a 5-second busy timeout.
  * Creates the merge_queue table and indexes if they do not already exist.
+ *
+ * @param projectRoot Optional. When provided, migration v3 backfills
+ *   `workstream_id` for pre-existing rows by reading
+ *   `.overstory/specs/<taskId>.meta.json`. Callers in snapshot/restore/eval
+ *   contexts should omit this — backfill silently skips; column is nullable.
  */
-export function createMergeQueue(dbPath: string): MergeQueue {
+export function createMergeQueue(dbPath: string, projectRoot?: string): MergeQueue {
 	const db = new Database(dbPath);
 
 	// Configure for concurrent access from multiple agent processes
@@ -194,7 +253,12 @@ export function createMergeQueue(dbPath: string): MergeQueue {
 
 	// Apply versioned migrations (compat_failed status + compat_report_path column + mission_id)
 	bootstrapSchemaVersion(db, "merge_queue", MIGRATIONS);
-	applyMigrations(db, MIGRATIONS);
+	projectRootForMigration = projectRoot ?? null;
+	try {
+		applyMigrations(db, MIGRATIONS);
+	} finally {
+		projectRootForMigration = null;
+	}
 
 	// Create mission index after migration v2 ensures the column exists
 	db.exec(CREATE_MISSION_INDEX);
@@ -206,13 +270,14 @@ export function createMergeQueue(dbPath: string): MergeQueue {
 			$branch_name: string;
 			$task_id: string;
 			$mission_id: string | null;
+			$workstream_id: string | null;
 			$agent_name: string;
 			$files_modified: string;
 			$enqueued_at: string;
 		}
 	>(`
-		INSERT INTO merge_queue (branch_name, task_id, mission_id, agent_name, files_modified, enqueued_at)
-		VALUES ($branch_name, $task_id, $mission_id, $agent_name, $files_modified, $enqueued_at)
+		INSERT INTO merge_queue (branch_name, task_id, mission_id, workstream_id, agent_name, files_modified, enqueued_at)
+		VALUES ($branch_name, $task_id, $mission_id, $workstream_id, $agent_name, $files_modified, $enqueued_at)
 		RETURNING *
 	`);
 
@@ -278,6 +343,7 @@ export function createMergeQueue(dbPath: string): MergeQueue {
 				$branch_name: input.branchName,
 				$task_id: input.taskId,
 				$mission_id: input.missionId ?? null,
+				$workstream_id: input.workstreamId ?? null,
 				$agent_name: input.agentName,
 				$files_modified: filesModifiedJson,
 				$enqueued_at: enqueuedAt,

--- a/src/schema-consistency.test.ts
+++ b/src/schema-consistency.test.ts
@@ -255,6 +255,7 @@ describe("SQL schema consistency", () => {
 				"resolved_tier",
 				"status",
 				"task_id",
+				"workstream_id",
 			].sort();
 
 			expect(actual).toEqual(expected);


### PR DESCRIPTION
Stacked on #194 (feat/ov-engine-fixes). Populates workstream_status table via merge pipeline, activating the SSOT path scaffolded in the parent PR.

## Changes

- merge_queue migration v3: new workstream_id column + per-row backfill via synchronous readFileSync of .overstory/specs/<taskId>.meta.json. ENOENT silent (legacy/non-mission branches); JSON parse errors logged to stderr.
- createMergeQueue accepts optional projectRoot — omitted in recovery/snapshot/eval contexts; required only from ov merge for backfill.
- handleBranch in ov merge looks up workstreamId via readSpecMeta when enqueueing; threads it to MergeEntry → recordWorkstreamMerge populates workstream_status + flips has_emitted_ws_producer_write=1.
- +2 queue tests: round-trip workstreamId + null default.

## Before/after

**Before**: every recordWorkstreamMerge hits warning branch; SSOT table empty; evaluateWsCompletion permanently in sticky fallback mode (≡ legacy first-merge behavior).

**After**: SSOT populates on every ov merge; sticky fallback permanently disabled per mission after first producer write; evaluateWsCompletion correctly waits for ALL planned workstreams merged before advancing execute phase.

## Test plan

- [x] bun test src/merge src/commands/merge.test.ts src/missions src/watchdog — all green on touched paths
- [x] tsc --noEmit — 12 pre-existing (0 new)
- [x] biome check — clean
- [ ] Live: after merge, migration v3 backfills openapi-contract-v2 rows; operator resumes mission; execute phase correctly waits for all WS merged

## Depends on

#194 — sits on top of it. Rebase onto main before squash-merge per plan's stacked-branch workflow.