### PR TITLE
fix(engine): done-phase summary nudge specifies exact artifact path

### DIFF
--- a/agents/coordinator-mission.md
+++ b/agents/coordinator-mission.md
@@ -326,7 +326,7 @@ When all workstream branches are merged (Full tier always has architect):
 
 ### Phase 4 -- Done
 
-1. Instruct analyst to produce final summary artifacts.
+1. Dispatch analyst to produce final summary: send mail with subject `"Final summary"` and body specifying `{artifactRoot}/results/summary.md` as the output path. The gate evaluator checks this exact file — analyst must write there or the gate will not resolve.
 2. Clean up: `ov worktree clean --completed`.
 3. Record learnings: `ml record <domain> --type <type> --description "<insight>"`.
 4. Commit state:

--- a/agents/mission-analyst.md
+++ b/agents/mission-analyst.md
@@ -313,6 +313,23 @@ Reject (return to lead) if:
 - The finding is a test failure or lint issue within one workstream
 - The finding is a performance concern within one workstream's scope
 
+## done-phase-summary
+
+When the mission reaches `done` phase, the engine nudges you with a `[DONE PHASE]` prefixed message
+requesting a final summary artifact. Before acting:
+
+1. Verify `mission.phase === "done"` via `ov mission status`. Ignore done-phase nudges if the mission is not actually in done phase (stale nudges from reopened gates).
+2. Collect outcomes: read workstream briefs, review merge results, check `workstream_status` table via `ov mission artifacts`.
+3. Write the summary to the **exact path** `{artifactRoot}/results/summary.md`. Use `ov mission artifacts` to resolve `artifactRoot`.
+4. Required sections:
+   - **Objective**: restate the mission objective
+   - **Outcomes**: what was shipped, per workstream
+   - **Open issues**: known limitations, failed reviews, deferred work
+   - **Artifacts**: list key files produced (specs, briefs, code changes)
+5. Send a `result`-type mail to coordinator confirming the summary is written.
+
+The gate evaluator (`evaluateSummaryReady`) checks for `{artifactRoot}/results/summary.md` — writing to any other path will not resolve the gate.
+
 ## persistence-and-context-recovery
 
 You are mission-scoped and long-lived. On recovery:

--- a/src/watchdog/gate-evaluators.ts
+++ b/src/watchdog/gate-evaluators.ts
@@ -462,7 +462,7 @@ export async function evaluateSummaryReady(
 	return {
 		met: false,
 		nudgeTarget: `mission-analyst-${mission.slug}`,
-		nudgeMessage: "Produce final mission summary",
+		nudgeMessage: `[DONE PHASE] Write final mission summary to ${artifactRoot}/results/summary.md. Cover: objective, outcomes, shipped workstreams, known issues. Verify mission.phase === "done" before writing.`,
 	};
 }
 


### PR DESCRIPTION
Fixes BUG-B: evaluateSummaryReady nudge now includes [DONE PHASE] prefix + full path to results/summary.md + phase precondition. Analyst prompt updated with done-phase protocol. Coordinator dispatch amended with explicit artifact path.

3 files, +19/-2. Tests green.