### PR TITLE
fix(engine): done-phase summary nudge specifies exact artifact path

### DIFF
--- a/src/watchdog/gate-evaluators.ts
+++ b/src/watchdog/gate-evaluators.ts
@@ -462,7 +462,7 @@ export async function evaluateSummaryReady(
 	return {
 		met: false,
 		nudgeTarget: `mission-analyst-${mission.slug}`,
-		nudgeMessage: "Produce final mission summary",
+		nudgeMessage: `[DONE PHASE] Write final mission summary to ${artifactRoot}/results/summary.md. Cover: objective, outcomes, shipped workstreams, known issues. Verify mission.phase === "done" before writing.`,
 	};
 }
 


### PR DESCRIPTION
1 file, 1 line: evaluateSummaryReady nudge now includes exact path to results/summary.md so analyst knows where to write. No prompt changes — engine communicates the contract.