### PR TITLE
fix(engine): plan-phase dispatch-planning gate false-suspend

### DIFF
--- a/src/missions/cells/plan-phase.ts
+++ b/src/missions/cells/plan-phase.ts
@@ -26,7 +26,7 @@ function buildSubgraph(_config: PhaseCellConfig): MissionGraph {
 				id: `${CELL_TYPE}:dispatch-planning`,
 				cellType: CELL_TYPE,
 				gate: "async",
-				gateTimeout: 120,
+				gateTimeout: 3600,
 			},
 			{
 				kind: "cell",

--- a/src/watchdog/gate-evaluators.test.ts
+++ b/src/watchdog/gate-evaluators.test.ts
@@ -10,6 +10,7 @@ import {
 	evaluateArchitectDesign,
 	evaluateAwaitPlan,
 	evaluateAwaitResearch,
+	evaluateDispatchPlanning,
 	evaluateGate,
 	evaluateUnderstandReady,
 	evaluateWsCompletion,
@@ -401,6 +402,62 @@ describe("evaluateWsCompletion", () => {
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("evaluateDispatchPlanning", () => {
+	it("coordinator dispatch to analyst after gate entry → met:true", () => {
+		const mission = makeMission({ slug: "test" });
+		const mailStore = createTestMailStore([
+			{
+				from: "coordinator-test",
+				to: "mission-analyst-test",
+				type: "dispatch",
+				subject: "Planning phase",
+				createdAt: "2026-04-18T10:05:00.000Z",
+			},
+		]);
+		const result = evaluateDispatchPlanning(mission, mailStore, "2026-04-18T10:00:00.000Z");
+		expect(result.met).toBe(true);
+		expect(result.trigger).toBe("planning_started");
+	});
+
+	it("analyst dispatched plan-review-lead → met:true (self-transition)", () => {
+		const mission = makeMission({ slug: "test" });
+		const mailStore = createTestMailStore([
+			{
+				from: "mission-analyst-test",
+				to: "plan-review-lead",
+				type: "dispatch",
+				subject: "Plan review request: test",
+				createdAt: "2026-04-18T10:01:00.000Z",
+			},
+		]);
+		const result = evaluateDispatchPlanning(mission, mailStore, "2026-04-18T10:03:00.000Z");
+		expect(result.met).toBe(true);
+		expect(result.trigger).toBe("planning_started");
+	});
+
+	it("analyst sent Plan complete result → met:true", () => {
+		const mission = makeMission({ slug: "test" });
+		const mailStore = createTestMailStore([
+			{
+				from: "mission-analyst-test",
+				to: "coordinator-test",
+				type: "result",
+				subject: "Plan complete: 2 workstreams",
+			},
+		]);
+		const result = evaluateDispatchPlanning(mission, mailStore);
+		expect(result.met).toBe(true);
+	});
+
+	it("no signals → met:false, nudge coordinator", () => {
+		const mission = makeMission({ slug: "test" });
+		const mailStore = createTestMailStore([]);
+		const result = evaluateDispatchPlanning(mission, mailStore);
+		expect(result.met).toBe(false);
+		expect(result.nudgeTarget).toBe("coordinator-test");
 	});
 });
 

--- a/src/watchdog/gate-evaluators.ts
+++ b/src/watchdog/gate-evaluators.ts
@@ -371,7 +371,8 @@ export function evaluateArchFinal(
 	};
 }
 
-/** Check if coordinator has dispatched analyst for planning. */
+/** Check if planning has started — either coordinator dispatched analyst, or
+ * analyst self-transitioned (spawned plan-review-lead or delivered the plan). */
 export function evaluateDispatchPlanning(
 	mission: Mission,
 	mailStore: MailStore | null,
@@ -380,13 +381,30 @@ export function evaluateDispatchPlanning(
 	if (!mailStore) return { met: false };
 
 	const analystName = `mission-analyst-${mission.slug}`;
-	const msgs = mailStore.getAll({ to: analystName });
-	const hasDispatch = msgs.some(
+
+	// Path 1: coordinator explicitly dispatched planning to analyst after gate entry.
+	const analystInbox = mailStore.getAll({ to: analystName });
+	const hasDispatch = analystInbox.some(
 		(m) => m.type === "dispatch" && (!gateEnteredAt || m.createdAt >= gateEnteredAt),
 	);
 	if (hasDispatch) {
 		return { met: true, trigger: "planning_started" };
 	}
+
+	// Path 2: analyst already in planning — spawned plan-review-lead or delivered
+	// a plan-complete result. No explicit coordinator dispatch is needed when
+	// the analyst auto-transitions after research. gateEnteredAt filter deliberately
+	// skipped: if these signals exist at all, planning is underway.
+	const analystOutbox = mailStore.getAll({ from: analystName });
+	const planningActive = analystOutbox.some(
+		(m) =>
+			m.to === "plan-review-lead" ||
+			(m.type === "result" && (m.subject ?? "").toLowerCase().includes("plan")),
+	);
+	if (planningActive) {
+		return { met: true, trigger: "planning_started" };
+	}
+
 	return {
 		met: false,
 		nudgeTarget: `coordinator-${mission.slug}`,


### PR DESCRIPTION
Fixes two-bug interaction killing healthy missions at plan-phase:dispatch-planning after 2 minutes.

## Root cause

**Bug 1 — timeout misconfig** (plan-phase.ts:29): gateTimeout=120s → max_total_wait_ms=120000 (2 min). Sibling nodes use 3600 (1 hour). Obvious misconfig.

**Bug 2 — evaluator mismatch** (gate-evaluators.ts): evaluateDispatchPlanning waits for type:"dispatch" mail TO analyst AFTER gate entry. In real flow analyst self-transitions to planning once research is done — coordinator's last dispatch happens BEFORE this gate enters. No fresh signal → gate stalls → 2-min ceiling hits → suspend.

## Live timeline (asrp.science-llm openapi-check)

```
09:58:24  coordinator → analyst: URGENT dispatch (BEFORE gate)
09:59:00  analyst → coordinator: Research complete
10:01:10  analyst → plan-review-lead: dispatch (self-transition)
10:03:31  engine entered dispatch-planning gate
10:06:40  engine_mission_suspended (149s, max=120000)
```

## Fix

- plan-phase.ts:29: 120 → 3600
- evaluateDispatchPlanning: second path matches analyst's own outbound — dispatch to plan-review-lead OR result-type with 'plan' in subject
- +4 tests

## Test plan
- [x] bun test: 919 pass / 2 fail (pre-existing E2E)
- [x] tsc: 12 errors (pre-existing baseline)
- [x] biome clean