### PR TITLE
fix(engine): direct-tier merge-all infinite loop + gate-state reset on loop-back

### DIFF
--- a/src/missions/cells/execute-direct-phase.test.ts
+++ b/src/missions/cells/execute-direct-phase.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { HandlerContext } from "../types.ts";
+import { executeDirectPhaseCell } from "./execute-direct-phase.ts";
+import type { PhaseCellDeps } from "./types.ts";
+
+function makeDeps(): PhaseCellDeps {
+	return {
+		mailSend: async () => {},
+		checkpointStore: {} as unknown as PhaseCellDeps["checkpointStore"],
+		missionStore: {} as unknown as PhaseCellDeps["missionStore"],
+	};
+}
+
+function makeCtx(checkpoint: unknown = null): HandlerContext {
+	return {
+		nodeId: "execute-phase:merge-all",
+		checkpoint,
+		getMission: () => null,
+	} as HandlerContext;
+}
+
+describe("execute-direct-phase merge-all handler", () => {
+	const handlers = executeDirectPhaseCell.buildHandlers(makeDeps());
+
+	test("allDone=true → trigger=all_merged", async () => {
+		const result = await handlers["merge-all"](makeCtx({ allDone: true }));
+		expect(result.trigger).toBe("all_merged");
+	});
+
+	test("morePending=true → trigger=more_leads", async () => {
+		const result = await handlers["merge-all"](makeCtx({ morePending: true }));
+		expect(result.trigger).toBe("more_leads");
+	});
+
+	test("no checkpoint signal → defaults to all_merged (prevents BUG-E loop)", async () => {
+		const result = await handlers["merge-all"](makeCtx(null));
+		expect(result.trigger).toBe("all_merged");
+	});
+
+	test("empty checkpoint object → defaults to all_merged", async () => {
+		const result = await handlers["merge-all"](makeCtx({}));
+		expect(result.trigger).toBe("all_merged");
+	});
+});

--- a/src/missions/cells/execute-direct-phase.ts
+++ b/src/missions/cells/execute-direct-phase.ts
@@ -93,7 +93,12 @@ function buildHandlers(_deps: PhaseCellDeps): HandlerRegistry {
 
 			if (data?.allDone) return { trigger: "all_merged" };
 			if (data?.morePending) return { trigger: "more_leads" };
-			return { trigger: "more_leads" };
+			// Default to all_merged: without an explicit morePending signal there are no
+			// known outstanding leads. Returning more_leads here caused infinite loops
+			// (back to await-leads-done) because nothing in the pipeline ever sets the
+			// checkpoint. If a multi-lead flow needs to re-dispatch, the coordinator or
+			// a gate evaluator must set morePending=true via a checkpoint write.
+			return { trigger: "all_merged" };
 		},
 	};
 }

--- a/src/missions/engine.ts
+++ b/src/missions/engine.ts
@@ -135,6 +135,18 @@ export function createGraphEngine(opts: GraphEngineOpts): GraphEngine {
 		opts.missionStore?.updateCurrentNode(opts.missionId, edge.to);
 		state.currentNodeId = edge.to;
 
+		// Reset gate state on loop-back: if the destination is a gate node other than
+		// the origin, its stale resolved_at would filter out post-entry signals and
+		// cause the evaluator to return met:false indefinitely (BUG-E).
+		const destNode = nodeMap.get(edge.to);
+		if (
+			destNode &&
+			edge.to !== fromNodeId &&
+			(destNode.gate === "async" || destNode.gate === "human")
+		) {
+			opts.missionStore?.resetGateState(opts.missionId, edge.to);
+		}
+
 		return { status: "advanced", fromNodeId, toNodeId: edge.to, trigger };
 	};
 

--- a/src/missions/test-mocks.ts
+++ b/src/missions/test-mocks.ts
@@ -228,6 +228,7 @@ export function createMockMissionStore(): MissionStore & { currentNode: string |
 			ceiling_emitted_at: null,
 		}),
 		incrementNudgeCount: noop,
+		resetGateState: noop,
 		markCeilingEmitted: noop,
 		resolveGate: noop,
 		updateTier: noop as unknown as MissionStore["updateTier"],


### PR DESCRIPTION
Fixes BUG-E: direct-tier missions hung at execute-phase:await-leads-done and eventually hit ceiling escalation despite merged work.

## Root cause (two-bug interaction)

1. **merge-all handler defaulted to more_leads** (execute-direct-phase.ts:95). Nothing writes checkpoint.allDone or checkpoint.morePending → every tick looped merge-all → await-leads-done.

2. **performAdvance didn't reset gate state on loop-back** (engine.ts). Stale resolved_at on await-leads-done made the evaluator's mail filter drop the original merge_ready signal → met:false → nudges → ceiling.

## Live evidence (m1-m3-fixes mission on asrp.science-llm)

```
gate resolved: 12:08:31 (lead_done trigger) ✓
engine_nudge_sent: 12:09, 12:10 (why?! gate resolved)
ceiling_emitted_at: 12:11:31
current_node stuck at await-leads-done
work still landed in main via mail flow
```

## Fix

- Flip merge-all default: no explicit signal → all_merged (terminal).
- performAdvance resets gate state on destination when it's a gate node and edge.to ≠ fromNodeId.
- +4 regression tests covering merge-all handler paths.

## Test plan
- [x] bun test: 923 pass / 2 fail (pre-existing E2E)
- [x] tsc: 12 errors (baseline)
- [x] biome clean