### PR TITLE
fix(pr-phase): push branch to origin before gh pr create (haru-b3df)

### DIFF
--- a/src/missions/cells/pr-phase.test.ts
+++ b/src/missions/cells/pr-phase.test.ts
@@ -73,6 +73,14 @@ function makeConfig(overrides?: ConfigOverrides): PhaseCellConfig {
 }
 
 function makeBaseDeps(overrides?: Partial<PhaseCellDeps>): PhaseCellDeps {
+	const defaultSpawn = ((_args: string[], _opts?: unknown) => {
+		return {
+			exited: Promise.resolve(0),
+			stdout: null,
+			stderr: null,
+			unref: () => {},
+		} as unknown as ReturnType<typeof Bun.spawn>;
+	}) as unknown as typeof Bun.spawn;
 	return {
 		mailSend: async () => {},
 		checkpointStore: {} as PhaseCellDeps["checkpointStore"],
@@ -80,6 +88,7 @@ function makeBaseDeps(overrides?: Partial<PhaseCellDeps>): PhaseCellDeps {
 		tracker: makeStubTracker(),
 		overstoryDir: "/tmp/overstory",
 		projectRoot: "/tmp/p",
+		spawn: defaultSpawn,
 		...(overrides ?? {}),
 	};
 }
@@ -1746,5 +1755,169 @@ describe("prPhaseCell create handler — MRP body rendering", () => {
 		);
 		expect(result.trigger).toBe("pr_already_exists");
 		expect(upsertCalls).toHaveLength(1);
+	});
+});
+
+// =============================================================================
+// push-before-create: T-w3-push-1 .. T-w3-push-5 + T-w3-push-4b
+// =============================================================================
+
+function makeStderrStream(text: string): ReadableStream {
+	return new ReadableStream({
+		start(c) {
+			c.enqueue(new TextEncoder().encode(text));
+			c.close();
+		},
+	});
+}
+
+describe("prPhaseCell create — push before gh pr create", () => {
+	let savedBudget: GhBudget | null;
+
+	beforeEach(() => {
+		savedBudget = null;
+		try {
+			savedBudget = getGhBudget();
+		} catch {
+			savedBudget = null;
+		}
+	});
+
+	afterEach(() => {
+		setGhBudget(savedBudget);
+	});
+
+	test("T-w3-push-1: git push is invoked before gh pr create", async () => {
+		const callOrder: string[] = [];
+		const fakeSpawn = ((args: readonly string[]) => {
+			callOrder.push(`spawn:${args.join(" ")}`);
+			return {
+				exited: Promise.resolve(0),
+				stdout: null,
+				stderr: null,
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget } = makeFakeGhBudget(({ args }) => {
+			if (args[0] === "pr" && args[1] === "create") {
+				callOrder.push("gh:pr-create");
+				return { exitCode: 0, stdout: "https://github.com/x/y/pull/1" };
+			}
+			return { exitCode: 0 };
+		});
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		const pushIdx = callOrder.findIndex((c) => c.startsWith("spawn:git push"));
+		const ghIdx = callOrder.indexOf("gh:pr-create");
+		expect(pushIdx).toBeGreaterThanOrEqual(0);
+		expect(ghIdx).toBeGreaterThan(pushIdx);
+	});
+
+	test("T-w3-push-2: push exit 0, gh pr create success → pr_created", async () => {
+		const fakeSpawn = ((_args: string[], _opts?: unknown) => {
+			return {
+				exited: Promise.resolve(0),
+				stdout: null,
+				stderr: null,
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget } = makeFakeGhBudget(({ args }) => {
+			if (args[0] === "pr" && args[1] === "create")
+				return { exitCode: 0, stdout: "https://github.com/x/y/pull/2" };
+			return { exitCode: 0 };
+		});
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		expect(result.trigger).toBe("pr_created");
+	});
+
+	test("T-w3-push-3: push fails (network) → pr_create_network_fail, gh pr create NOT called", async () => {
+		const calls: Array<{ args: readonly string[] }> = [];
+		const fakeSpawn = ((args: readonly string[], _opts?: unknown) => {
+			calls.push({ args });
+			return {
+				exited: Promise.resolve(1),
+				stdout: null,
+				stderr: makeStderrStream("fatal: could not read from remote repository\n"),
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget, calls: ghCalls } = makeFakeGhBudget(() => ({ exitCode: 0 }));
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		expect(result.trigger).toBe("pr_create_network_fail");
+		expect(ghCalls.some((c) => c.args[0] === "pr" && c.args[1] === "create")).toBe(false);
+	});
+
+	test("T-w3-push-4: protected branch → pr_branch_protected, gh pr create NOT called", async () => {
+		const fakeSpawn = ((_args: string[], _opts?: unknown) => {
+			return {
+				exited: Promise.resolve(1),
+				stdout: null,
+				stderr: makeStderrStream(
+					"remote: error: GH006: Protected branch update failed for refs/heads/feature/x.\n",
+				),
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget, calls: ghCalls } = makeFakeGhBudget(() => ({ exitCode: 0 }));
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		expect(result.trigger).toBe("pr_branch_protected");
+		expect(ghCalls.some((c) => c.args[0] === "pr" && c.args[1] === "create")).toBe(false);
+	});
+
+	test("T-w3-push-4b: pre-receive hook declined → pr_branch_protected, gh pr create NOT called", async () => {
+		const fakeSpawn = ((_args: string[], _opts?: unknown) => {
+			return {
+				exited: Promise.resolve(1),
+				stdout: null,
+				stderr: makeStderrStream("remote: pre-receive hook declined\n"),
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget, calls: ghCalls } = makeFakeGhBudget(() => ({ exitCode: 0 }));
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		expect(result.trigger).toBe("pr_branch_protected");
+		expect(ghCalls.some((c) => c.args[0] === "pr" && c.args[1] === "create")).toBe(false);
+	});
+
+	test("T-w3-push-5: Everything up-to-date (exit 0) → pr_created", async () => {
+		const fakeSpawn = ((_args: string[], _opts?: unknown) => {
+			return {
+				exited: Promise.resolve(0),
+				stdout: null,
+				stderr: makeStderrStream("Everything up-to-date\n"),
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+		const { budget } = makeFakeGhBudget(({ args }) => {
+			if (args[0] === "pr" && args[1] === "create")
+				return { exitCode: 0, stdout: "https://github.com/x/y/pull/5" };
+			return { exitCode: 0 };
+		});
+		setGhBudget(budget);
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: fakeSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+		expect(result.trigger).toBe("pr_created");
 	});
 });

--- a/src/missions/cells/pr-phase.ts
+++ b/src/missions/cells/pr-phase.ts
@@ -204,6 +204,21 @@ function buildHandlers(deps: PhaseCellDeps, config?: PhaseCellConfig): HandlerRe
 				return { trigger: "pr_no_commits" };
 			}
 
+			const spawnFn = deps.spawn ?? Bun.spawn;
+			const pushProc = spawnFn(["git", "push", "-u", "origin", featureBranch], {
+				cwd: deps.projectRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const pushExit = await pushProc.exited;
+			if (pushExit !== 0) {
+				const pushStderr = pushProc.stderr ? await new Response(pushProc.stderr).text() : "";
+				if (/protected branch/i.test(pushStderr) || /pre-receive hook declined/i.test(pushStderr)) {
+					return { trigger: "pr_branch_protected" };
+				}
+				return { trigger: "pr_create_network_fail" };
+			}
+
 			const title = mission?.slug ?? featureBranch;
 			const mrpPath = join(mission?.artifactRoot ?? "", "merge-readiness-pack.json");
 			const taskIdForFooter = mission && isRealTaskId(mission.taskId) ? mission.taskId : undefined;


### PR DESCRIPTION
Replaces #420 (rebased onto main after #419 squash-merge).

Fixes haru-b3df: pr-phase:create called `gh pr create --head <featureBranch>` without pushing the branch to origin first. Result: pr_create_network_fail → paused → mission skipped PR creation.

Fix: add `git push -u origin <featureBranch>` before gh pr create.

Closes haru-b3df