### PR TITLE
fix(watchdog): idempotent start + heartbeat content (overstory-9da0)

### DIFF
--- a/src/missions/lifecycle-start.ts
+++ b/src/missions/lifecycle-start.ts
@@ -346,10 +346,14 @@ export async function missionStart(
 			const config = await loadConfig(projectRoot);
 			if (config.watchdog.tier0Enabled) {
 				const watchdog = createWatchdogControl(projectRoot);
-				const watchdogResult = await watchdog.start();
+				// Idempotency guard (haru-9da0): skip spawn entirely when a live,
+				// fresh daemon already owns the PID file. Prevents lifecycle-command
+				// churn from accumulating redundant `bun run ... watch` processes.
+				const alreadyRunning = await watchdog.isRunning();
+				const watchdogResult = alreadyRunning ? null : await watchdog.start();
 				if (watchdogResult && !opts.json) {
 					printHint("Watchdog started");
-				} else if (!opts.json) {
+				} else if (!alreadyRunning && !opts.json) {
 					const err = await getLastStartError(projectRoot).catch(() => null);
 					if (err) printWarning(`Watchdog failed to start: ${err.split("\n")[0]}`);
 				}
@@ -713,10 +717,14 @@ export async function missionResumeAll(
 			try {
 				if (config.watchdog.tier0Enabled) {
 					const watchdog = createWatchdogControl(projectRoot);
-					const watchdogResult = await watchdog.start();
+					// Idempotency guard (haru-9da0): skip spawn entirely when a live,
+					// fresh daemon already owns the PID file. Prevents lifecycle-command
+					// churn from accumulating redundant `bun run ... watch` processes.
+					const alreadyRunning = await watchdog.isRunning();
+					const watchdogResult = alreadyRunning ? null : await watchdog.start();
 					if (watchdogResult && !json) {
 						printHint("Watchdog started");
-					} else if (!json) {
+					} else if (!alreadyRunning && !json) {
 						const err = await getLastStartError(projectRoot).catch(() => null);
 						if (err) printWarning(`Watchdog failed to start: ${err.split("\n")[0]}`);
 					}

--- a/src/watchdog/control.ts
+++ b/src/watchdog/control.ts
@@ -76,8 +76,23 @@ async function isHeartbeatFresh(
 ): Promise<boolean> {
 	const file = Bun.file(heartbeatPath);
 	if (!(await file.exists())) return false;
+	const threshold = now() - 2 * intervalMs;
+	// Prefer the heartbeat file contents (ms-since-epoch integer the daemon
+	// writes every tick). Fall back to mtime when contents are absent or
+	// unparseable so older daemons without content writes still report fresh.
+	try {
+		const text = (await file.text()).trim();
+		if (text.length > 0) {
+			const hb = Number.parseInt(text, 10);
+			if (!Number.isNaN(hb) && hb > 0) {
+				return hb >= threshold;
+			}
+		}
+	} catch {
+		// Fall through to mtime check
+	}
 	const stat = await file.stat();
-	return stat.mtimeMs >= now() - 2 * intervalMs;
+	return stat.mtimeMs >= threshold;
 }
 
 async function truncateStderrLog(stderrLogPath: string): Promise<void> {


### PR DESCRIPTION
Rebased onto main; replaces #422. Fixes overstory-9da0 daemon leak.

3-layer fix:
1. createWatchdogControl.start() short-circuits on healthy daemon
2. lifecycle-start.ts call-site isRunning() guard
3. Content-aware isHeartbeatFresh

Closes overstory-9da0