### PR TITLE
fix(missions): add migration v18 to widen phase CHECK for arch-review (haru-6438)

### DIFF
--- a/src/missions/store.test.ts
+++ b/src/missions/store.test.ts
@@ -1663,6 +1663,42 @@ describe("setTaskId round-trip (ws-store-types)", () => {
 	});
 });
 
+describe("migration v18: arch-review phase CHECK", () => {
+	test("T-v18-1: INSERT with phase='arch-review' succeeds after migration", () => {
+		const raw = new Database(dbPath);
+		try {
+			const now = new Date().toISOString();
+			expect(() =>
+				raw.exec(
+					`INSERT INTO missions (id, slug, objective, phase, state, created_at, updated_at, paused_workstream_ids, paused_lead_names, pending_user_input, reopen_count, learnings_extracted, has_emitted_ws_producer_write, autonomy)
+					 VALUES ('mission-ar-1', 'ar-slug-1', 'obj', 'arch-review', 'active', '${now}', '${now}', '[]', '[]', 0, 0, 0, 0, 'supervised')`,
+				),
+			).not.toThrow();
+		} finally {
+			raw.close();
+		}
+	});
+
+	test("T-v18-2: migration v18 is idempotent — re-opening store is a no-op", () => {
+		store.close();
+		expect(() => {
+			store = createMissionStore(dbPath);
+		}).not.toThrow();
+
+		const raw = new Database(dbPath);
+		try {
+			const schema = raw
+				.prepare<{ sql: string }, []>(
+					"SELECT sql FROM sqlite_master WHERE type='table' AND name='missions'",
+				)
+				.get();
+			expect(schema?.sql).toContain("'arch-review'");
+		} finally {
+			raw.close();
+		}
+	});
+});
+
 describe("v14 / v16 rebuild column-list literals — da-risk-11 regression guard", () => {
 	test("T-da-risk-11-1: v14 rebuildTable columns array does NOT contain 'task_id' (would brick legacy DBs)", async () => {
 		// Static-string scan: walk the on-disk source of store.ts and find the

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS missions (
   state TEXT NOT NULL DEFAULT 'active'
     CHECK(state IN ('active','frozen','completed','failed','stopped','suspended','superseded','pr-phase')),
   phase TEXT NOT NULL DEFAULT 'intake'
-    CHECK(phase IN ('intake','understand','align','decide','plan','execute','pr','pre-pr','done')),
+    CHECK(phase IN ('intake','understand','align','decide','plan','execute','arch-review','pr','pre-pr','done')),
   first_freeze_at TEXT,
   frozen_at TEXT,
   pending_user_input INTEGER NOT NULL DEFAULT 0,
@@ -977,6 +977,68 @@ const MISSION_MIGRATIONS: Migration[] = [
 			}
 		},
 		detect: (db) => hasColumn(db, "missions", "task_id"),
+	},
+	{
+		version: 18,
+		description: "Extend missions.phase CHECK to allow 'arch-review' phase",
+		up: (db) => {
+			const schemaRow = db
+				.prepare<{ sql: string }, []>(
+					"SELECT sql FROM sqlite_master WHERE type='table' AND name='missions'",
+				)
+				.get();
+			if (!schemaRow || schemaRow.sql.includes("'arch-review'")) {
+				return;
+			}
+			rebuildTable({
+				db,
+				table: "missions",
+				createSql: CREATE_TABLE.replace("CREATE TABLE IF NOT EXISTS", "CREATE TABLE"),
+				columns: [
+					"id",
+					"slug",
+					"objective",
+					"run_id",
+					"state",
+					"phase",
+					"first_freeze_at",
+					"frozen_at",
+					"pending_user_input",
+					"pending_input_kind",
+					"pending_input_thread_id",
+					"reopen_count",
+					"artifact_root",
+					"paused_workstream_ids",
+					"analyst_session_id",
+					"execution_director_session_id",
+					"coordinator_session_id",
+					"architect_session_id",
+					"paused_lead_names",
+					"pause_reason",
+					"current_node",
+					"started_at",
+					"completed_at",
+					"created_at",
+					"updated_at",
+					"learnings_extracted",
+					"tier",
+					"has_emitted_ws_producer_write",
+					"autonomy",
+					"feature_branch",
+					"parent_mission_id",
+					"learnings_extracted_at",
+					"task_id",
+				],
+			});
+		},
+		detect: (db) => {
+			const schemaRow = db
+				.prepare<{ sql: string }, []>(
+					"SELECT sql FROM sqlite_master WHERE type='table' AND name='missions'",
+				)
+				.get();
+			return !!schemaRow && schemaRow.sql.includes("'arch-review'");
+		},
 	},
 ];
 


### PR DESCRIPTION
Fixes **haru-6438**: missions.phase CHECK constraint at `src/missions/store.ts:84` omitted 'arch-review'. When engine called `performAdvance(execute:active → arch-review:active)`, SQLite threw SQLITE_CONSTRAINT_CHECK errno 275 — silently swallowed in mission-tick. Full-tier missions silently stuck at execute phase.

## Fix

Migration v18 widens CHECK to include 'arch-review'. Mirrors v16 rebuild pattern (which added pr/pre-pr but forgot arch-review).

- Idempotent (rebuild skipped if 'arch-review' already in CHECK)
- Updates inline `CREATE_TABLE` for fresh installs

## Tests

`bun test src/missions/store.test.ts` green.

Closes haru-6438