### PR TITLE
fix(lifecycle): propagate resume errors + restart ED for execute-tier (haru-4911)

### DIFF
--- a/src/missions/lifecycle-start.test.ts
+++ b/src/missions/lifecycle-start.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StartPersistentAgentResult } from "../agents/persistent-root.ts";
 import { buildAgentManifest } from "../commands/init.ts";
+import { openSessionStore } from "../sessions/compat.ts";
 import { missionResumeAll, missionStart } from "./lifecycle-start.ts";
 import type { MissionCommandDeps } from "./lifecycle-types.ts";
 import { createMissionStore } from "./store.ts";
@@ -349,12 +350,7 @@ describe("missionResumeAll", () => {
 			const stale = new Date(Date.now() - 3900_000).toISOString();
 			rawDb.run(
 				"INSERT INTO mission_gate_state (mission_id, node_id, entered_at, nudge_count, last_nudge_at, respawn_count, last_respawn_at, grace_ms, nudge_interval_ms, max_nudges, max_total_wait_ms, resolved_at, resolved_trigger, ceiling_emitted_at) VALUES (?, ?, ?, 0, NULL, 0, NULL, 120000, 60000, 3, 3600000, NULL, NULL, ?)",
-				[
-					"mission-gate-reset-test",
-					"understand-phase:evaluate",
-					stale,
-					stale,
-				],
+				["mission-gate-reset-test", "understand-phase:evaluate", stale, stale],
 			);
 		} finally {
 			rawDb.close();
@@ -392,6 +388,283 @@ describe("missionResumeAll", () => {
 		} finally {
 			verifyStore.close();
 		}
+	});
+
+	test("OOM recovery — all sessions completed → resume restarts all 3 roles and warns OOM", async () => {
+		const missionId = "mission-oom-test";
+		const runId = "run-oom-test";
+		const now = new Date().toISOString();
+
+		// Seed a suspended full-tier execute-phase mission
+		const store = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			store.create({
+				id: missionId,
+				slug: "oom-test",
+				objective: "verify OOM recovery",
+				runId,
+				artifactRoot: join(overstoryDir, "missions", missionId),
+				tier: "full",
+			});
+			store.updateState(missionId, "suspended");
+			store.updatePhase(missionId, "execute");
+		} finally {
+			store.close();
+		}
+
+		// Insert 3 completed sessions (simulates post-OOM state)
+		const { store: sessionStore } = openSessionStore(overstoryDir);
+		try {
+			const base = {
+				capability: "test",
+				runtime: "claude",
+				worktreePath: "/tmp",
+				branchName: "main",
+				taskId: "",
+				tmuxSession: "ha-oom",
+				pid: null,
+				parentAgent: null,
+				depth: 0,
+				runId,
+				startedAt: now,
+				lastActivity: now,
+				escalationLevel: 0,
+				stalledSince: null,
+				rateLimitedSince: null,
+				runtimeSessionId: null,
+				transcriptPath: null,
+				originalRuntime: null,
+				statusLine: null,
+			};
+			sessionStore.upsert({
+				...base,
+				id: "sess-coord-oom",
+				agentName: "coordinator-oom-test",
+				state: "completed",
+				tmuxSession: "ha-coord-oom",
+			});
+			sessionStore.upsert({
+				...base,
+				id: "sess-analyst-oom",
+				agentName: "mission-analyst-oom-test",
+				state: "completed",
+				tmuxSession: "ha-analyst-oom",
+			});
+			sessionStore.upsert({
+				...base,
+				id: "sess-ed-oom",
+				agentName: "execution-director-oom-test",
+				state: "completed",
+				tmuxSession: "ha-ed-oom",
+			});
+		} finally {
+			sessionStore.close();
+		}
+
+		let coordCalled = 0;
+		let analystCalled = 0;
+		let edCalled = 0;
+		const deps = {
+			startMissionCoordinator: async (_opts: unknown) => {
+				coordCalled++;
+				return makeRoleStub("coord-new")(_opts);
+			},
+			startMissionAnalyst: async (_opts: unknown) => {
+				analystCalled++;
+				return makeRoleStub("analyst-new")(_opts);
+			},
+			startExecutionDirector: async (_opts: unknown) => {
+				edCalled++;
+				return makeRoleStub("ed-new")(_opts);
+			},
+		} as unknown as MissionCommandDeps;
+
+		let captured = "";
+		const origWrite = process.stdout.write;
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+			return true;
+		}) as typeof process.stdout.write;
+
+		process.exitCode = 0;
+		try {
+			await missionResumeAll(overstoryDir, projectRoot, false, missionId, deps);
+		} finally {
+			process.stdout.write = origWrite;
+		}
+
+		expect(process.exitCode).toBe(0);
+		expect(captured).toMatch(/OOM|all.*completed|completed.*OOM/i);
+		expect(coordCalled).toBe(1);
+		expect(analystCalled).toBe(1);
+		expect(edCalled).toBe(1);
+
+		// Verify ED session was bound on the mission
+		const verify = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			const m = verify.getById(missionId);
+			expect(m?.executionDirectorSessionId).toBe("ed-new");
+		} finally {
+			verify.close();
+		}
+
+		process.exitCode = 0;
+	});
+
+	test("ED restart for execute phase — full tier + execute phase → startExecutionDirector invoked", async () => {
+		const missionId = "mission-ed-execute";
+		const runId = "run-ed-execute";
+
+		const store = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			store.create({
+				id: missionId,
+				slug: "ed-execute",
+				objective: "verify ED restart for execute",
+				runId,
+				artifactRoot: join(overstoryDir, "missions", missionId),
+				tier: "full",
+			});
+			store.updateState(missionId, "suspended");
+			store.updatePhase(missionId, "execute");
+		} finally {
+			store.close();
+		}
+
+		let edCalled = 0;
+		const deps = {
+			startMissionCoordinator: makeRoleStub(
+				"coord-ed",
+			) as unknown as MissionCommandDeps["startMissionCoordinator"],
+			startMissionAnalyst: makeRoleStub(
+				"analyst-ed",
+			) as unknown as MissionCommandDeps["startMissionAnalyst"],
+			startExecutionDirector: async (_opts: unknown) => {
+				edCalled++;
+				return makeRoleStub("ed-exec")(_opts);
+			},
+		} as unknown as MissionCommandDeps;
+
+		process.exitCode = 0;
+		await missionResumeAll(overstoryDir, projectRoot, true, missionId, deps);
+
+		expect(process.exitCode).toBe(0);
+		expect(edCalled).toBe(1);
+
+		// Verify ED session was bound
+		const verify = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			const m = verify.getById(missionId);
+			expect(m?.executionDirectorSessionId).toBe("ed-exec");
+		} finally {
+			verify.close();
+		}
+
+		process.exitCode = 0;
+	});
+
+	test("No ED restart for non-execute phases — full tier + understand phase → startExecutionDirector NOT invoked", async () => {
+		const missionId = "mission-no-ed-understand";
+		const runId = "run-no-ed-understand";
+
+		const store = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			store.create({
+				id: missionId,
+				slug: "no-ed-understand",
+				objective: "verify no ED for understand phase",
+				runId,
+				artifactRoot: join(overstoryDir, "missions", missionId),
+				tier: "full",
+			});
+			store.updateState(missionId, "suspended");
+			store.updatePhase(missionId, "understand");
+		} finally {
+			store.close();
+		}
+
+		let edCalled = 0;
+		const deps = {
+			startMissionCoordinator: makeRoleStub(
+				"coord-no-ed",
+			) as unknown as MissionCommandDeps["startMissionCoordinator"],
+			startMissionAnalyst: makeRoleStub(
+				"analyst-no-ed",
+			) as unknown as MissionCommandDeps["startMissionAnalyst"],
+			startExecutionDirector: async (_opts: unknown) => {
+				edCalled++;
+				return makeRoleStub("ed-no-exec")(_opts);
+			},
+		} as unknown as MissionCommandDeps;
+
+		process.exitCode = 0;
+		await missionResumeAll(overstoryDir, projectRoot, true, missionId, deps);
+
+		expect(process.exitCode).toBe(0);
+		expect(edCalled).toBe(0);
+
+		process.exitCode = 0;
+	});
+
+	test("Direct tier — only coordinator restarted, analyst and ED skipped, message omits mission-analyst", async () => {
+		const missionId = "mission-direct-tier";
+		const runId = "run-direct-tier";
+
+		const store = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			store.create({
+				id: missionId,
+				slug: "direct-tier",
+				objective: "verify direct tier restart",
+				runId,
+				artifactRoot: join(overstoryDir, "missions", missionId),
+				tier: "direct",
+			});
+			store.updateState(missionId, "suspended");
+			store.updatePhase(missionId, "execute");
+		} finally {
+			store.close();
+		}
+
+		let coordCalled = 0;
+		let analystCalled = 0;
+		let edCalled = 0;
+		const deps = {
+			startMissionCoordinator: async (_opts: unknown) => {
+				coordCalled++;
+				return makeRoleStub("coord-direct")(_opts);
+			},
+			startMissionAnalyst: async (_opts: unknown) => {
+				analystCalled++;
+				return makeRoleStub("analyst-direct")(_opts);
+			},
+			startExecutionDirector: async (_opts: unknown) => {
+				edCalled++;
+				return makeRoleStub("ed-direct")(_opts);
+			},
+		} as unknown as MissionCommandDeps;
+
+		let captured = "";
+		const origWrite = process.stdout.write;
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+			return true;
+		}) as typeof process.stdout.write;
+
+		process.exitCode = 0;
+		try {
+			await missionResumeAll(overstoryDir, projectRoot, false, missionId, deps);
+		} finally {
+			process.stdout.write = origWrite;
+		}
+
+		expect(process.exitCode).toBe(0);
+		expect(coordCalled).toBe(1);
+		expect(analystCalled).toBe(0);
+		expect(edCalled).toBe(0);
+		expect(captured).not.toMatch(/mission-analyst/i);
+
+		process.exitCode = 0;
 	});
 });
 

--- a/src/missions/lifecycle-start.ts
+++ b/src/missions/lifecycle-start.ts
@@ -30,7 +30,12 @@ import {
 	sendMissionDispatchMail,
 } from "./messaging.ts";
 import { applyContinueFrom } from "./predecessor.ts";
-import { startMissionAnalyst, startMissionCoordinator, stopMissionRole } from "./roles.ts";
+import {
+	startExecutionDirector,
+	startMissionAnalyst,
+	startMissionCoordinator,
+	stopMissionRole,
+} from "./roles.ts";
 import { removeActiveMission, writeMissionRuntimePointers } from "./runtime-context.ts";
 import { generateSlugFromIntent } from "./slug.ts";
 import { createMissionStore } from "./store.ts";
@@ -432,27 +437,34 @@ export async function missionStart(
 }
 
 /**
- * Restart coordinator and mission-analyst from scratch against an existing mission.
- * Used by resume when prior sessions are gone (e.g. after --kill).
+ * Restart coordinator and mission roles from scratch against an existing mission.
+ * Used by resume when prior sessions are gone (e.g. after --kill or OOM).
+ * Returns per-role results for accurate status reporting in the caller.
  */
 async function restartMissionRoles(
 	overstoryDir: string,
 	projectRoot: string,
 	mission: import("../types.ts").Mission,
-): Promise<void> {
+	deps?: MissionCommandDeps,
+): Promise<Array<{ agentName: string; success: boolean; error?: string }>> {
 	if (!mission.runId) {
 		throw new Error(`Mission ${mission.id} has no runId — cannot restart roles`);
 	}
 	const runId = mission.runId;
 	const tier = mission.tier;
+	const startCoord = deps?.startMissionCoordinator ?? startMissionCoordinator;
+	const startAnalyst = deps?.startMissionAnalyst ?? startMissionAnalyst;
+	const startEd = deps?.startExecutionDirector ?? startExecutionDirector;
 
 	// Stage A: tier=null means mission is still in intake phase — there are no
 	// persistent roles to restart. The intake-phase subgraph (driven by the
 	// watchdog tick) re-spawns ephemeral clarifier/analyst-intake/tier-classifier
 	// agents on the next tick if needed.
 	if (tier === null) {
-		return;
+		return [];
 	}
+
+	const results: Array<{ agentName: string; success: boolean; error?: string }> = [];
 
 	// Slug-scoped agent names (mirrors missionStart pattern)
 	const coordAgentName = mission.slug ? `coordinator-${mission.slug}` : "coordinator";
@@ -484,7 +496,7 @@ async function restartMissionRoles(
 	});
 	drainAgentInbox(overstoryDir, coordAgentName);
 
-	const coordResult = await startMissionCoordinator({
+	const coordResult = await startCoord({
 		missionId: mission.id,
 		missionSlug: mission.slug,
 		agentName: coordAgentName,
@@ -505,6 +517,7 @@ async function restartMissionRoles(
 	} finally {
 		missionStore.close();
 	}
+	results.push({ agentName: coordAgentName, success: true });
 
 	// Conditionally spawn analyst — only for planned/full tiers
 	if (tier === "planned" || tier === "full") {
@@ -521,7 +534,7 @@ async function restartMissionRoles(
 		});
 		drainAgentInbox(overstoryDir, analystAgentName);
 
-		const analystResult = await startMissionAnalyst({
+		const analystResult = await startAnalyst({
 			missionId: mission.id,
 			missionSlug: mission.slug,
 			agentName: analystAgentName,
@@ -543,6 +556,7 @@ async function restartMissionRoles(
 		} finally {
 			missionStore2.close();
 		}
+		results.push({ agentName: analystAgentName, success: true });
 
 		// Notify analyst of resumed mission
 		await sendMissionControlMail({
@@ -563,6 +577,72 @@ async function restartMissionRoles(
 		await nudgeMissionRoleBestEffort(
 			projectRoot,
 			analystAgentName,
+			`Mission resumed: ${mission.slug}. Check mail and review prior work.`,
+		);
+	}
+
+	// Conditionally spawn execution-director — only for full tier in execute-tier phases
+	if (
+		tier === "full" &&
+		(mission.phase === "execute" ||
+			mission.phase === "arch-review" ||
+			mission.phase === "pre-pr" ||
+			mission.phase === "pr")
+	) {
+		const edPrompt = await materializeMissionRolePrompt({
+			overstoryDir,
+			agentName: edAgentName,
+			capability: "execution-director",
+			roleLabel: "Execution Director",
+			mission,
+			siblingNames: {
+				"Coordinator agent": coordAgentName,
+				"Mission Analyst agent": analystAgentName,
+			},
+		});
+		drainAgentInbox(overstoryDir, edAgentName);
+
+		const edResult = await startEd({
+			missionId: mission.id,
+			missionSlug: mission.slug,
+			agentName: edAgentName,
+			projectRoot,
+			overstoryDir,
+			existingRunId: runId,
+			appendSystemPromptFile: edPrompt.promptPath,
+			beacon: buildMissionRoleBeacon({
+				agentName: edAgentName,
+				missionId: mission.id,
+				contextPath: edPrompt.contextPath,
+			}),
+		});
+
+		const edStore = createMissionStore(join(overstoryDir, "sessions.db"));
+		try {
+			edStore.bindSessions(mission.id, { executionDirectorSessionId: edResult.session.id });
+		} finally {
+			edStore.close();
+		}
+		results.push({ agentName: edAgentName, success: true });
+
+		await sendMissionControlMail({
+			overstoryDir,
+			to: edAgentName,
+			subject: `Mission resumed: ${mission.slug}`,
+			body: [
+				`Mission ID: ${mission.id}`,
+				`Objective: ${mission.objective}`,
+				`Artifact root: ${mission.artifactRoot ?? "none"}`,
+				`Context file: ${edPrompt.contextPath}`,
+				"",
+				"This mission is being RESUMED. Check artifacts for prior execution state.",
+				"Report findings to coordinator via mail.",
+			].join("\n"),
+			type: "dispatch",
+		});
+		await nudgeMissionRoleBestEffort(
+			projectRoot,
+			edAgentName,
 			`Mission resumed: ${mission.slug}. Check mail and review prior work.`,
 		);
 	}
@@ -594,6 +674,8 @@ async function restartMissionRoles(
 		coordAgentName,
 		`Mission resumed: ${mission.slug}. Check mail and review prior artifacts.`,
 	);
+
+	return results;
 }
 
 export async function missionResumeAll(
@@ -601,6 +683,7 @@ export async function missionResumeAll(
 	projectRoot: string,
 	json: boolean,
 	missionId?: string,
+	deps?: MissionCommandDeps,
 ): Promise<void> {
 	// Find suspended mission
 	const resolvedMissionId = missionId ?? (await resolveCurrentMissionId(overstoryDir));
@@ -688,12 +771,55 @@ export async function missionResumeAll(
 			const results: Array<{ agentName: string; success: boolean; error?: string }> = [];
 
 			if (ordered.length === 0) {
-				// No resumable sessions — restart roles fresh against existing mission
-				await restartMissionRoles(overstoryDir, projectRoot, mission);
-				results.push({ agentName: "coordinator", success: true });
-				results.push({ agentName: "mission-analyst", success: true });
+				// No resumable sessions — restart roles fresh against existing mission.
+				// Distinguish OOM (all prior sessions completed) from a clean first-run.
+				const isOom = allSessions.length > 0 && allSessions.every((s) => s.state === "completed");
+				let restartResults: Array<{ agentName: string; success: boolean; error?: string }>;
+				try {
+					restartResults = await restartMissionRoles(overstoryDir, projectRoot, mission, deps);
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					if (json) {
+						jsonError("mission resume", msg);
+					} else {
+						printError("Resume failed", msg);
+					}
+					process.exitCode = 1;
+					return;
+				}
+				results.push(...restartResults);
 				if (!json) {
-					printSuccess("Restarted coordinator and mission-analyst (no prior sessions to resume)");
+					const mTier = mission.tier;
+					const edRestarted = restartResults.some((r) =>
+						r.agentName.startsWith("execution-director"),
+					);
+					if (isOom) {
+						const parts: string[] = ["coordinator"];
+						if (mTier === "planned" || mTier === "full") parts.push("mission-analyst");
+						if (edRestarted) parts.push("execution-director");
+						let rolesStr: string;
+						if (parts.length === 1) {
+							rolesStr = parts[0] ?? "coordinator";
+						} else if (parts.length === 2) {
+							rolesStr = `${parts[0] ?? ""} and ${parts[1] ?? ""}`;
+						} else {
+							const last = parts[parts.length - 1] ?? "";
+							rolesStr = `${parts.slice(0, -1).join(", ")} and ${last}`;
+						}
+						printWarning(
+							`Restarted ${rolesStr} (prior sessions were all marked completed — recovering from likely OOM)`,
+						);
+					} else {
+						const freshParts: string[] = ["coordinator"];
+						if (mTier === "planned" || mTier === "full") freshParts.push("mission-analyst");
+						let freshRolesStr: string;
+						if (freshParts.length === 1) {
+							freshRolesStr = freshParts[0] ?? "coordinator";
+						} else {
+							freshRolesStr = `${freshParts[0] ?? ""} and ${freshParts[1] ?? ""}`;
+						}
+						printSuccess(`Restarted ${freshRolesStr} (fresh mission run had no prior sessions)`);
+					}
 				}
 			} else {
 				for (const session of ordered) {


### PR DESCRIPTION
Fixes **haru-4911**: `ha mission resume` reported success but silently failed when all role sessions were marked completed (e.g., after OOM). Coordinator/analyst/ED were not actually spawned. Also: ED was never restarted for full-tier missions stuck in execute phase.

## Fix

1. Propagate spawn errors loudly in `restartMissionRoles` (previously swallowed)
2. Include execution-director restart when `mission.phase` ∈ {execute, arch-review, pre-pr, pr}
3. Distinguish OOM (all sessions completed) vs fresh restart messages

## Tests

Tests pass; biome clean.

Closes haru-4911