### PR TITLE
fix(coordinator): record mulch before worktree cleanup (overstory-ee23, #386)

### DIFF
--- a/agents/coordinator-mission-direct.md
+++ b/agents/coordinator-mission-direct.md
@@ -244,8 +244,8 @@ When all work streams are merged and issues closed:
 
 1. Verify all issues are closed: `{{TRACKER_CLI}} show <id>` for each.
 2. Verify all branches are merged: `ha status` for unmerged branches.
-3. Clean up worktrees: `ha worktree clean --completed`.
-4. Record learnings: `ku record <domain> --type <type> --description "<insight>"`.
+3. Record learnings FIRST (before cleanup, so any uncommitted `.mulch/` state in agent worktrees is preserved): `ku record <domain> --type <type> --description "<insight>"`.
+4. Clean up worktrees ONLY AFTER learnings are recorded: `ha worktree clean --completed`.
 5. Commit state:
    ```bash
    {{TRACKER_CLI}} sync

--- a/agents/coordinator-mission-full.md
+++ b/agents/coordinator-mission-full.md
@@ -356,8 +356,8 @@ When all workstream branches are merged (Full tier always has architect):
 ### Phase 4 -- Done
 
 1. Instruct analyst to produce final summary artifacts.
-2. Clean up: `ha worktree clean --completed`.
-3. Record learnings: `ku record <domain> --type <type> --description "<insight>"`.
+2. Record learnings FIRST (before cleanup, so any uncommitted `.mulch/` state in agent worktrees is preserved): `ku record <domain> --type <type> --description "<insight>"`.
+3. Clean up ONLY AFTER learnings are recorded: `ha worktree clean --completed`.
 4. Commit state:
    ```bash
    {{TRACKER_CLI}} sync

--- a/agents/coordinator-mission-planned.md
+++ b/agents/coordinator-mission-planned.md
@@ -255,8 +255,8 @@ Goal: Monitor execution, merge completed work, handle issues.
 ### Phase 4 — Done
 
 1. Instruct analyst to produce final summary artifacts.
-2. Clean up: `ha worktree clean --completed`.
-3. Record learnings: `ku record <domain> --type <type> --description "<insight>"`.
+2. Record learnings FIRST (before cleanup, so any uncommitted `.mulch/` state in agent worktrees is preserved): `ku record <domain> --type <type> --description "<insight>"`.
+3. Clean up ONLY AFTER learnings are recorded: `ha worktree clean --completed`.
 4. Commit state:
    ```bash
    {{TRACKER_CLI}} sync

--- a/agents/coordinator-mission.md
+++ b/agents/coordinator-mission.md
@@ -344,8 +344,8 @@ When all workstream branches are merged (Full tier always has architect):
 ### Phase 4 -- Done
 
 1. Instruct analyst to produce final summary artifacts.
-2. Clean up: `ha worktree clean --completed`.
-3. Record learnings: `ku record <domain> --type <type> --description "<insight>"`.
+2. Record learnings FIRST (before cleanup, so any uncommitted `.mulch/` state in agent worktrees is preserved): `ku record <domain> --type <type> --description "<insight>"`.
+3. Clean up ONLY AFTER learnings are recorded: `ha worktree clean --completed`.
 4. Commit state:
    ```bash
    {{TRACKER_CLI}} sync

--- a/agents/coordinator.md
+++ b/agents/coordinator.md
@@ -304,8 +304,8 @@ When a batch is complete (task group auto-closed, all issues resolved):
 
 1. Verify all issues are closed: run `{{TRACKER_CLI}} show <id>` for each issue in the group.
 2. Verify all branches are merged: check `ha status` for unmerged branches. If any branch is unmerged, do NOT proceed — wait for the lead's `merge_ready` signal.
-3. Clean up worktrees: `ha worktree clean --completed`.
-4. Record orchestration insights: `ku record <domain> --type <type> --classification <foundational|tactical|observational> --description "<insight>"`.
+3. Record orchestration insights FIRST (before cleanup, so any uncommitted `.mulch/` state in agent worktrees is preserved): `ku record <domain> --type <type> --classification <foundational|tactical|observational> --description "<insight>"`.
+4. Clean up worktrees ONLY AFTER mulch is recorded: `ha worktree clean --completed`.
 5. Commit and sync state files: after all work is merged and issues are closed, commit any outstanding state changes so runtime state is not left uncommitted when the coordinator goes idle:
    ```bash
    {{TRACKER_CLI}} sync


### PR DESCRIPTION
## Summary

Coordinator completion-protocol cleaned worktrees BEFORE recording mulch learnings, destroying uncommitted `.mulch/` state in scout/builder worktrees. Discovery runs effectively lost their findings.

Reorder steps so `ku record` runs FIRST, then `ha worktree clean --completed`.

Fixed in all 5 coordinator agent definitions:
- agents/coordinator.md
- agents/coordinator-mission.md
- agents/coordinator-mission-direct.md
- agents/coordinator-mission-planned.md
- agents/coordinator-mission-full.md

## Test plan
- [ ] Verify a new discovery/mission run records mulch entries before worktrees are cleaned
- [ ] Confirm \`ku query <domain>\` returns records after mission completion

Closes #386