### PR TITLE
fix(watchdog): plug test-driven daemon leak (NODE_ENV-aware opt-out)

### DIFF
--- a/src/commands/mission.test.ts
+++ b/src/commands/mission.test.ts
@@ -266,6 +266,7 @@ describe("missionStart concurrency guard", () => {
 	let guardOverstoryDir: string;
 	let originalStdout: typeof process.stdout.write;
 	let originalStderr: typeof process.stderr.write;
+	let originalDisableWatchdog: string | undefined;
 
 	beforeEach(async () => {
 		guardDir = await mkdtemp(join(tmpdir(), "mission-guard-test-"));
@@ -280,12 +281,21 @@ describe("missionStart concurrency guard", () => {
 		originalStderr = process.stderr.write;
 		process.stdout.write = (() => true) as typeof process.stdout.write;
 		process.stderr.write = (() => true) as typeof process.stderr.write;
+		// Prevent missionStart auto-spawning watchdog daemons that leak past
+		// cleanupTempDir (detached children get reparented to systemd).
+		originalDisableWatchdog = process.env.HARU_DISABLE_WATCHDOG_AUTO_START;
+		process.env.HARU_DISABLE_WATCHDOG_AUTO_START = "1";
 	});
 
 	afterEach(async () => {
 		process.exitCode = 0;
 		process.stdout.write = originalStdout;
 		process.stderr.write = originalStderr;
+		if (originalDisableWatchdog === undefined) {
+			delete process.env.HARU_DISABLE_WATCHDOG_AUTO_START;
+		} else {
+			process.env.HARU_DISABLE_WATCHDOG_AUTO_START = originalDisableWatchdog;
+		}
 		await cleanupTempDir(guardDir);
 	});
 

--- a/src/watchdog/control.ts
+++ b/src/watchdog/control.ts
@@ -221,6 +221,15 @@ export function createWatchdogControl(
 
 	return {
 		async start(): Promise<{ pid: number } | null> {
+			// Test-isolation guard: callers that don't want auto-spawn (notably tests
+			// transitively invoking missionStart/coordinator/sling, whose detached
+			// daemon child gets reparented to systemd and survives `cleanupTempDir`,
+			// accumulating leaked `bun run … watch` processes) opt out by setting
+			// HARU_DISABLE_WATCHDOG_AUTO_START=1.
+			if (process.env.HARU_DISABLE_WATCHDOG_AUTO_START === "1") {
+				return null;
+			}
+
 			// Ensure state/ exists before we try to open the stderr log
 			mkdirSync(stateDir, { recursive: true });
 


### PR DESCRIPTION
## Root cause

\`bun test src/commands/mission.test.ts\` was leaking daemons. The leaking tests live in describe block **\"missionStart concurrency guard\"** — each test:

1. \`mkdtemp\` → temp project root
2. Calls \`missionStart()\`
3. \`missionStart\` calls \`createWatchdogControl(projectRoot).start()\` (lifecycle-start.ts:357)
4. \`start()\` spawns a detached \`bun run … watch --background\` child
5. Test ends, \`cleanupTempDir\` removes the temp dir
6. Detached daemon is reparented to **systemd** and keeps running, holding fds on the now-deleted DB files

Confirmed via \`readlink /proc/<pid>/fd/*\` showing references to \`/tmp/mission-guard-test-*/.haru/*.db (deleted)\`.

Each test run added ~13 daemons; over a few full test runs we hit hundreds. The lock fix from #424 only prevented duplicate spawns from a single caller — it did not prevent the test fixture from spawning into systemd.

## Fix

- \`src/watchdog/control.ts\`: \`createWatchdogControl().start()\` honors \`HARU_DISABLE_WATCHDOG_AUTO_START=1\` and returns \`null\` immediately (no spawn, no lock acquisition).
- \`src/commands/mission.test.ts\`: \`missionStart concurrency guard\` describe block sets the env var in \`beforeEach\`, restores in \`afterEach\`.

## Verified

- \`bun test src/commands/mission.test.ts -t \"concurrency guard\"\` → 3 pass, **0 new daemons** (was 13)
- \`bun test src/watchdog/control.test.ts\` → 24 pass (integration tests unaffected — they don't set the env var)
- \`/proc\` walk after test run: still only the production daemon

## Test plan
- [ ] Run \`bun test src/commands/mission.test.ts\` multiple times; \`ps aux | grep \"bun run.*watch\"\` count stays constant
- [ ] Production lifecycle paths unaffected (env var not set in normal runs)