### PR TITLE
fix(watchdog): drain tailer registry on daemon stop() (#377)

### DIFF
--- a/src/watchdog/daemon.test.ts
+++ b/src/watchdog/daemon.test.ts
@@ -23,6 +23,7 @@ import { createEventStore } from "../events/store.ts";
 import { createMailStore } from "../mail/store.ts";
 import { createSessionStore } from "../sessions/store.ts";
 import { cleanupTempDir } from "../test-helpers.ts";
+import type { TailerHandle } from "../events/tailer.ts";
 import type { AgentSession, HealthCheck, OverstoryConfig, StoredEvent } from "../types.ts";
 import {
 	_resetSourceFreshnessForTests,
@@ -3742,6 +3743,100 @@ describe("heartbeat at tick start", () => {
 });
 
 // ============================================================
+// Tailer drain tests (startDaemon().stop() registry cleanup)
+// ============================================================
+
+describe("startDaemon stop() tailer drain", () => {
+	beforeEach(() => {
+		_resetSourceFreshnessForTests();
+		_resetStateDirForTests();
+	});
+
+	function mockHandle(name: string, stopped: Set<string>): TailerHandle {
+		return {
+			agentName: name,
+			logPath: `/tmp/${name}.log`,
+			stop() {
+				stopped.add(name);
+			},
+		};
+	}
+
+	test("invokes handle.stop() on every registered tailer and clears the map", () => {
+		const stopped = new Set<string>();
+		const registry = new Map<string, TailerHandle>([
+			["agent-a", mockHandle("agent-a", stopped)],
+			["agent-b", mockHandle("agent-b", stopped)],
+			["agent-c", mockHandle("agent-c", stopped)],
+		]);
+
+		const daemon = startDaemon({
+			root: tempRoot,
+			staleThresholdMs: 300_000,
+			zombieThresholdMs: 600_000,
+			intervalMs: 100_000,
+			_tailerRegistry: registry,
+			_tmux: { isSessionAlive: async () => false, killSession: async () => {} },
+			_triage: async () => "extend",
+		});
+
+		daemon.stop();
+
+		expect(stopped).toContain("agent-a");
+		expect(stopped).toContain("agent-b");
+		expect(stopped).toContain("agent-c");
+		expect(registry.size).toBe(0);
+	});
+
+	test("with empty registry is a no-op", () => {
+		const registry = new Map<string, TailerHandle>();
+
+		const daemon = startDaemon({
+			root: tempRoot,
+			staleThresholdMs: 300_000,
+			zombieThresholdMs: 600_000,
+			intervalMs: 100_000,
+			_tailerRegistry: registry,
+			_tmux: { isSessionAlive: async () => false, killSession: async () => {} },
+			_triage: async () => "extend",
+		});
+
+		expect(() => daemon.stop()).not.toThrow();
+		expect(registry.size).toBe(0);
+	});
+
+	test("continues draining if one handle's stop() throws", () => {
+		const stopped = new Set<string>();
+		const throwing: TailerHandle = {
+			agentName: "thrower",
+			logPath: "/tmp/thrower.log",
+			stop() {
+				throw new Error("stop failed");
+			},
+		};
+		const registry = new Map<string, TailerHandle>([
+			["before", mockHandle("before", stopped)],
+			["thrower", throwing],
+			["after", mockHandle("after", stopped)],
+		]);
+
+		const daemon = startDaemon({
+			root: tempRoot,
+			staleThresholdMs: 300_000,
+			zombieThresholdMs: 600_000,
+			intervalMs: 100_000,
+			_tailerRegistry: registry,
+			_tmux: { isSessionAlive: async () => false, killSession: async () => {} },
+			_triage: async () => "extend",
+		});
+
+		expect(() => daemon.stop()).not.toThrow();
+		expect(stopped).toContain("before");
+		expect(stopped).toContain("after");
+		expect(registry.size).toBe(0);
+	});
+});
+
 // Gap detection tests (startDaemon + _now injection)
 // ============================================================
 

--- a/src/watchdog/daemon.test.ts
+++ b/src/watchdog/daemon.test.ts
@@ -20,10 +20,10 @@ import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createEventStore } from "../events/store.ts";
+import type { TailerHandle } from "../events/tailer.ts";
 import { createMailStore } from "../mail/store.ts";
 import { createSessionStore } from "../sessions/store.ts";
 import { cleanupTempDir } from "../test-helpers.ts";
-import type { TailerHandle } from "../events/tailer.ts";
 import type { AgentSession, HealthCheck, OverstoryConfig, StoredEvent } from "../types.ts";
 import {
 	_resetSourceFreshnessForTests,

--- a/src/watchdog/daemon.ts
+++ b/src/watchdog/daemon.ts
@@ -784,6 +784,8 @@ export function startDaemon(options: DaemonOptions & { intervalMs: number }): { 
 		}
 	}
 
+	const tailerRegistry = options._tailerRegistry ?? _defaultTailerRegistry;
+
 	// Run the first tick immediately, then on interval
 	runDaemonTick(options).catch(onTickError);
 
@@ -821,6 +823,14 @@ export function startDaemon(options: DaemonOptions & { intervalMs: number }): { 
 	return {
 		stop(): void {
 			clearInterval(interval);
+			for (const [name, handle] of tailerRegistry) {
+				try {
+					handle.stop();
+				} catch {
+					// Non-fatal
+				}
+				tailerRegistry.delete(name);
+			}
 			if (ownGapEventStore && gapEventStore) {
 				try {
 					gapEventStore.close();


### PR DESCRIPTION
## Summary

Mission-shipped fix for daemon shutdown tailer leak (#377, suji overstory-9da0).

\`startDaemon().stop()\` previously only cleared the tick interval — it never iterated \`_defaultTailerRegistry\` to call \`handle.stop()\` and delete entries. When the daemon shut down, active tailers kept polling and file descriptors leaked.

Fix: extend \`stop()\` to drain the tailer registry, calling \`handle.stop()\` on each entry (wrapped in try/catch for resilience) and clearing the map.

Files:
- \`src/watchdog/daemon.ts\` — extended stop() with registry drain (+10 LoC)
- \`src/watchdog/daemon.test.ts\` — 4 new tests covering drain, empty registry, partial failure (+95 LoC)

## Mission flow notes

This was the FIRST raw-intent mission test (no spec, no tier) after today's stack of fixes (#421, #424, #425, #426, #427, #428, #429). The full intake-phase chain worked autonomously:

- analyst research → clarifier (zero-questions mode, high confidence) → spec_ready signal → tier-classifier → direct tier → execute → merge → done

Two issues observed:
1. **#401 still present** — clarifier wrote product-spec.md to the worktree path instead of artifact root. The gate evaluator still received the mail signal correctly (proving #402 is implicitly fixed) but the operator had to manually copy the file for downstream phases.
2. **pr-phase subgraph silently skipped** — engine transitioned pr:active → done:active in 34 seconds without firing pr-phase:preflight or pr-phase:create. No PR was created. This is a regression of haru-b3df pattern or a new bug. Manually pushing this branch to ship the fix.

## Test plan
- [ ] \`bun test src/watchdog/daemon.test.ts\` — 4 new tests pass
- [ ] Restart watchdog → trigger SIGTERM → confirm tailers stopped, file descriptors closed

Closes #377