### PR TITLE
fix(pr-phase + intake): unblock auto-PR creation (#401 + new pr-phase bypass)

### DIFF
--- a/src/missions/cells/pr-phase.ts
+++ b/src/missions/cells/pr-phase.ts
@@ -205,11 +205,29 @@ function buildHandlers(deps: PhaseCellDeps, config?: PhaseCellConfig): HandlerRe
 			}
 
 			const spawnFn = deps.spawn ?? Bun.spawn;
-			const pushProc = spawnFn(["git", "push", "-u", "origin", featureBranch], {
+			// The local feature_branch was created at mission start pointing to
+			// origin/main, but builder merges land on local `main`, leaving
+			// feature_branch stale. Reset it to local main HEAD so the push
+			// carries the merged work; without this, gh pr create sees no diff
+			// between head and base and fails silently into pr_create_network_fail.
+			const resetProc = spawnFn(["git", "branch", "-f", featureBranch, "main"], {
 				cwd: deps.projectRoot,
 				stdout: "pipe",
 				stderr: "pipe",
 			});
+			await resetProc.exited;
+
+			// Use --force-with-lease so the local update is reflected on origin
+			// without clobbering unrelated remote work; the remote ref was
+			// previously the stale origin/main, so this is the legitimate update.
+			const pushProc = spawnFn(
+				["git", "push", "--force-with-lease", "-u", "origin", featureBranch],
+				{
+					cwd: deps.projectRoot,
+					stdout: "pipe",
+					stderr: "pipe",
+				},
+			);
 			const pushExit = await pushProc.exited;
 			if (pushExit !== 0) {
 				const pushStderr = pushProc.stderr ? await new Response(pushProc.stderr).text() : "";

--- a/src/watchdog/gate-evaluators.ts
+++ b/src/watchdog/gate-evaluators.ts
@@ -6,7 +6,7 @@
  * and optionally a nudge target/message if the condition is not met.
  */
 
-import { statSync as statSyncFn } from "node:fs";
+import { copyFileSync, existsSync, statSync as statSyncFn } from "node:fs";
 import { join as joinPath } from "node:path";
 import { detectHaruDir } from "../config.ts";
 import type { MailStore } from "../mail/store.ts";
@@ -933,6 +933,7 @@ export function evaluateAwaitSpecReady(
 	mission: Mission,
 	mailStore: MailStore | null,
 	gateEnteredAt?: string,
+	projectRoot?: string,
 ): GateEvalResult {
 	if (!mailStore) return { met: false };
 
@@ -942,6 +943,33 @@ export function evaluateAwaitSpecReady(
 		(m) => m.type === "spec_ready",
 	);
 	if (ready) {
+		// Bug fix (overstory-#401): the clarifier writes product-spec.md inside
+		// its worktree (`<artifactRoot>/product-spec.md` interpreted relative to
+		// worktree root, not canonical), so downstream handlers like
+		// create-tracker-issue can't find it. Detect + copy from the predictable
+		// worktree path before signalling the gate is met. Best-effort: missing
+		// worktree copy just leaves the canonical path empty for the operator.
+		if (projectRoot && mission.artifactRoot && mission.slug) {
+			const canonicalSpec = joinPath(mission.artifactRoot, "product-spec.md");
+			if (!existsSync(canonicalSpec)) {
+				const worktreeSpec = joinPath(
+					projectRoot,
+					".overstory",
+					"worktrees",
+					mission.slug,
+					`product-clarifier-${mission.slug}`,
+					"product-spec.md",
+				);
+				if (existsSync(worktreeSpec)) {
+					try {
+						copyFileSync(worktreeSpec, canonicalSpec);
+					} catch {
+						// Non-fatal: human-spec-review or create-tracker-issue will
+						// surface the missing-spec error if the copy fails.
+					}
+				}
+			}
+		}
 		return { met: true, trigger: "spec_ready" };
 	}
 
@@ -1339,7 +1367,7 @@ export async function evaluateGate(
 		case "await-research-complete":
 			return evaluateAwaitResearchComplete(mission, stores.mailStore, gateEnteredAt);
 		case "await-spec-ready":
-			return evaluateAwaitSpecReady(mission, stores.mailStore, gateEnteredAt);
+			return evaluateAwaitSpecReady(mission, stores.mailStore, gateEnteredAt, projectRoot);
 		case "await-tier-set":
 			return evaluateAwaitTierSet(mission);
 		case "await-context":


### PR DESCRIPTION
## Two bugs from end-to-end mission test

### 1. pr-phase: stale feature_branch silently breaks gh pr create (NEW)

**Root cause:**
- \`materializeFeatureBranch\` at mission start: \`git branch <name> origin/main\` — points at pre-mission SHA
- Builder branches merge into local \`main\`, NOT into mission feature_branch
- pr-phase:create pushes stale feature_branch to origin
- \`gh pr create --head <stale> --base main\` fails with no commits between
- Trigger falls through to \`pr_create_network_fail\` → \`paused\` terminal
- Parent engine fires \`phase_advance\` pr:active → done:active
- Mission completes 'successfully' with NO PR

**Fix:** Reset local feature_branch to local main HEAD before push, then \`--force-with-lease\` push.

### 2. #401: clarifier writes spec to worktree path

**Root cause:** product-clarifier runs in isolated worktree with overlay enforcing 'all writes go to worktree copy'. Agent resolves \`<artifactRoot>/product-spec.md\` relative to worktree root → spec lands at \`.overstory/worktrees/<slug>/product-clarifier-<slug>/product-spec.md\` instead of canonical \`.overstory/missions/<id>/product-spec.md\`.

**Fix:** evaluateAwaitSpecReady copies worktree spec → canonical path before signalling spec_ready.

## Verified

- bun test src/watchdog/gate-evaluators.test.ts: 91 pass, 0 fail
- Bug #1 verified live in mission fix-daemon-shutdown-tailer-leak-377: branch \`mission/fix-daemon-shutdown-tailer-leak-377\` on origin = 663a455d (old base) NOT 071b17ef (builder commit)
- Bug #2 verified live in same mission: spec at \`worktrees/.../product-clarifier-.../product-spec.md\` (manually copied to canonical path to unblock approve gate)

## Test plan
- [ ] Next mission start \"<intent>\" with autonomy=auto-all → pr-phase succeeds end-to-end, PR created
- [ ] Spec materializes at canonical artifact root without manual copy

Closes #401