### PR TITLE
fix(missions): mulch extract + CLI tick-lock (#430, #431)

### DIFF
--- a/src/missions/cells/architecture-review.test.ts
+++ b/src/missions/cells/architecture-review.test.ts
@@ -221,6 +221,7 @@ function createMockMissionStore(): MissionStore {
 		checkpoints: createMockCheckpointStore(),
 		acquireTickLock: () => true,
 		releaseTickLock: noop,
+		withTickLock: async <T>(_id: string, fn: () => Promise<T>): Promise<T> => fn(),
 		ensureGateState: () => ({
 			entered_at: new Date().toISOString(),
 			nudge_count: 0,

--- a/src/missions/cells/done-phase.ts
+++ b/src/missions/cells/done-phase.ts
@@ -283,6 +283,37 @@ function buildHandlers(deps: PhaseCellDeps): HandlerRegistry {
 					);
 				}
 			}
+			// Bug fix #430: extract mulch learnings BEFORE worktree teardown.
+			// terminateMissionOwnedAgents + cleanupMissionWorktrees below remove
+			// scout/builder worktrees that may carry uncommitted `.mulch/` state.
+			// Generate the bundle (summary/sessions/metrics JSON) then run the
+			// extractor. Both steps are best-effort: failure logs + mission
+			// proceeds to teardown so operators can still close the run.
+			if (mission && deps.projectRoot && deps.overstoryDir && mission.artifactRoot) {
+				try {
+					const { exportBundle } = await import("../bundle.ts");
+					const { extractMissionLearnings } = await import("../learnings.ts");
+					const dbPath = join(deps.overstoryDir, "sessions.db");
+					await exportBundle({
+						overstoryDir: deps.overstoryDir,
+						dbPath,
+						missionId: mission.id,
+						force: false,
+					});
+					await extractMissionLearnings({
+						bundlePath: join(mission.artifactRoot, "results"),
+						artifactRoot: mission.artifactRoot,
+						projectRoot: deps.projectRoot,
+						missionSlug: mission.slug ?? mission.id,
+					});
+				} catch (err) {
+					console.warn(
+						`[done-phase:cleanup] learnings extraction failed (best-effort): ${
+							err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200)
+						}`,
+					);
+				}
+			}
 			// Stage C: clean up debug worktrees on success path.
 			// Escalation path leaves them in place for operator inspection.
 			if (mission && deps.projectRoot) {

--- a/src/missions/cells/plan-review.test.ts
+++ b/src/missions/cells/plan-review.test.ts
@@ -221,6 +221,7 @@ function createMockMissionStore(): MissionStore {
 		checkpoints: createMockCheckpointStore(),
 		acquireTickLock: () => true,
 		releaseTickLock: noop,
+		withTickLock: async <T>(_id: string, fn: () => Promise<T>): Promise<T> => fn(),
 		ensureGateState: () => ({
 			entered_at: new Date().toISOString(),
 			nudge_count: 0,

--- a/src/missions/engine.test.ts
+++ b/src/missions/engine.test.ts
@@ -257,6 +257,7 @@ function createMockMissionStore(): MissionStore & { currentNode: string | null }
 		checkpoints: createMockCheckpointStore(),
 		acquireTickLock: () => true,
 		releaseTickLock: noop,
+		withTickLock: async <T>(_id: string, fn: () => Promise<T>): Promise<T> => fn(),
 		ensureGateState: () => ({
 			entered_at: new Date().toISOString(),
 			nudge_count: 0,

--- a/src/missions/lifecycle-suspend.ts
+++ b/src/missions/lifecycle-suspend.ts
@@ -93,17 +93,21 @@ export async function suspendMission(opts: {
 			}
 		}
 
-		// Set mission state to suspended (preserves runtime pointers, mail, run)
-		const result = await transitionMissionViaEngine(mission.id, "suspend", {
-			checkpointStore: missionStore.checkpoints,
-			missionStore,
-		});
-		if (result.status === "error") {
-			const { printWarning } = await import("../logging/color.ts");
-			printWarning("Graph transition failed", result.error ?? "unknown");
-		}
+		// Set mission state to suspended (preserves runtime pointers, mail, run).
+		// Bug fix #431: hold the tick lock so an in-flight engine tick can't
+		// advance currentNode after we mark the mission suspended.
 		const beforeState = mission.state;
-		missionStore.updateState(mission.id, "suspended");
+		await missionStore.withTickLock(mission.id, async () => {
+			const result = await transitionMissionViaEngine(mission.id, "suspend", {
+				checkpointStore: missionStore.checkpoints,
+				missionStore,
+			});
+			if (result.status === "error") {
+				const { printWarning } = await import("../logging/color.ts");
+				printWarning("Graph transition failed", result.error ?? "unknown");
+			}
+			missionStore.updateState(mission.id, "suspended");
+		});
 		recordMissionEvent({
 			overstoryDir,
 			mission,

--- a/src/missions/lifecycle-terminate.ts
+++ b/src/missions/lifecycle-terminate.ts
@@ -284,49 +284,63 @@ async function terminalizeMission(opts: {
 		const beforeState = mission.state;
 		const beforePhase = mission.phase;
 		const engineDeps = { checkpointStore: missionStore.checkpoints, missionStore };
-		if (targetState === "completed") {
-			// Graph-aware: there is no single `complete` edge from execute/pr → done
-			// anymore. Inspect the current node and fire the next-step trigger
-			// (phase_advance or handoff). When already on done:active (or no edge
-			// exists), skip the graph transition — the explicit completeMission()
-			// below still finalizes the mission record.
-			const completionTrigger = resolveCompletionTrigger(mission);
-			if (completionTrigger) {
-				const result = await transitionMissionViaEngine(mission.id, completionTrigger, engineDeps);
+		// Bug fix #431: serialize against in-flight mission ticks. Without the
+		// tick lock, the watchdog tick may read mission state, decide to advance,
+		// then write a new currentNode AFTER our stop/complete state mutation
+		// lands — leaving the mission in an inconsistent stopped+advancing state.
+		const earlyReturn = await missionStore.withTickLock(mission.id, async () => {
+			if (targetState === "completed") {
+				// Graph-aware: there is no single `complete` edge from execute/pr → done
+				// anymore. Inspect the current node and fire the next-step trigger
+				// (phase_advance or handoff). When already on done:active (or no edge
+				// exists), skip the graph transition — the explicit completeMission()
+				// below still finalizes the mission record.
+				const completionTrigger = resolveCompletionTrigger(mission);
+				if (completionTrigger) {
+					const result = await transitionMissionViaEngine(
+						mission.id,
+						completionTrigger,
+						engineDeps,
+					);
+					if (result.status === "error") {
+						printWarning("Graph transition failed", result.error ?? "unknown");
+						return { earlyReturn: true } as const;
+					}
+					// If advance moved to intermediate phase (not done), let engine tick run it
+					const advancedMission = missionStore.getById(mission.id);
+					if (advancedMission?.phase !== "done") {
+						printSuccess(
+							"Mission advanced to intermediate phase",
+							`Current phase: ${advancedMission?.phase}. Engine will progress through remaining phases on next ticks.`,
+						);
+						return { earlyReturn: true } as const;
+					}
+				}
+				missionStore.transaction(() => {
+					if (mission.phase !== "done") {
+						missionStore.updatePhase(mission.id, "done");
+					}
+					missionStore.completeMission(mission.id);
+				});
+				if (mission.phase !== "done") {
+					recordMissionEvent({
+						overstoryDir,
+						mission,
+						agentName: "operator",
+						data: { kind: "phase_change", from: beforePhase, to: "done" },
+					});
+				}
+			} else {
+				const result = await transitionMissionViaEngine(mission.id, "stop", engineDeps);
 				if (result.status === "error") {
 					printWarning("Graph transition failed", result.error ?? "unknown");
-					return { bundlePath: null, reviewId: null, deferredSelfSession: selfTmuxSession };
 				}
-				// If advance moved to intermediate phase (not done), let engine tick run it
-				const advancedMission = missionStore.getById(mission.id);
-				if (advancedMission?.phase !== "done") {
-					printSuccess(
-						"Mission advanced to intermediate phase",
-						`Current phase: ${advancedMission?.phase}. Engine will progress through remaining phases on next ticks.`,
-					);
-					return { bundlePath: null, reviewId: null, deferredSelfSession: selfTmuxSession };
-				}
+				missionStore.updateState(mission.id, "stopped");
 			}
-			missionStore.transaction(() => {
-				if (mission.phase !== "done") {
-					missionStore.updatePhase(mission.id, "done");
-				}
-				missionStore.completeMission(mission.id);
-			});
-			if (mission.phase !== "done") {
-				recordMissionEvent({
-					overstoryDir,
-					mission,
-					agentName: "operator",
-					data: { kind: "phase_change", from: beforePhase, to: "done" },
-				});
-			}
-		} else {
-			const result = await transitionMissionViaEngine(mission.id, "stop", engineDeps);
-			if (result.status === "error") {
-				printWarning("Graph transition failed", result.error ?? "unknown");
-			}
-			missionStore.updateState(mission.id, "stopped");
+			return { earlyReturn: false } as const;
+		});
+		if (earlyReturn.earlyReturn) {
+			return { bundlePath: null, reviewId: null, deferredSelfSession: selfTmuxSession };
 		}
 
 		recordMissionEvent({

--- a/src/missions/store.ts
+++ b/src/missions/store.ts
@@ -1642,6 +1642,30 @@ export function createMissionStore(dbPath: string): MissionStore {
 			};
 		})(),
 
+		async withTickLock<T>(
+			missionId: string,
+			fn: () => Promise<T>,
+			opts?: { maxWaitMs?: number; intervalMs?: number },
+		): Promise<T> {
+			const maxWaitMs = opts?.maxWaitMs ?? 5_000;
+			const intervalMs = opts?.intervalMs ?? 100;
+			const deadline = Date.now() + maxWaitMs;
+			let held = false;
+			while (Date.now() < deadline) {
+				if (this.acquireTickLock(missionId, maxWaitMs)) {
+					held = true;
+					break;
+				}
+				await Bun.sleep(intervalMs);
+			}
+			try {
+				return await fn();
+			} finally {
+				// Best-effort release; safe even if we never acquired (DELETE is a no-op).
+				if (held) this.releaseTickLock(missionId);
+			}
+		},
+
 		ensureGateState: (() => {
 			const insertStmt = db.prepare(
 				`INSERT OR IGNORE INTO mission_gate_state

--- a/src/missions/test-mocks.ts
+++ b/src/missions/test-mocks.ts
@@ -227,6 +227,7 @@ export function createMockMissionStore(): MissionStore & { currentNode: string |
 		checkpoints: createMockCheckpointStore(),
 		acquireTickLock: () => true,
 		releaseTickLock: noop,
+		withTickLock: async <T>(_id: string, fn: () => Promise<T>): Promise<T> => fn(),
 		ensureGateState: () => ({
 			entered_at: new Date().toISOString(),
 			nudge_count: 0,

--- a/src/missions/types.ts
+++ b/src/missions/types.ts
@@ -566,6 +566,19 @@ export interface MissionStore {
 	// === Gate state operations (for mission engine tick) ===
 	acquireTickLock(missionId: string, intervalMs: number): boolean;
 	releaseTickLock(missionId: string): void;
+	/**
+	 * Run `fn` while holding the per-mission tick lock so CLI mutations
+	 * (ha mission stop/pause/resume) serialize against in-flight ticks.
+	 * Polls acquireTickLock with backoff up to `maxWaitMs` (default 5000ms);
+	 * returns the result of `fn`. If the lock can't be acquired within the
+	 * deadline, `fn` runs anyway (best-effort serialization, no deadlock).
+	 * See overstory-#431.
+	 */
+	withTickLock<T>(
+		missionId: string,
+		fn: () => Promise<T>,
+		opts?: { maxWaitMs?: number; intervalMs?: number },
+	): Promise<T>;
 	ensureGateState(
 		missionId: string,
 		nodeId: string,


### PR DESCRIPTION
## #430: done-phase auto-runs extract-learnings before teardown

Previously `done-phase cleanup` removed agent worktrees (including their uncommitted `.mulch/` state) before any mulch extraction. Only operators running `ha mission extract-learnings` manually could rescue those records.

Fix: cleanup handler now imports exportBundle + extractMissionLearnings and runs them before `terminateMissionOwnedAgents` / `cleanupMissionWorktrees`. Best-effort: failure logs and mission proceeds.

## #431: CLI mutations honor mission_tick_lock

Spec overstory-7d7f criterion #2 said: 'Concurrent tick + manual command cannot interleave; the second waits for the first to release.'

The mission_tick_lock infrastructure existed but only mission-tick used it. CLI mutations (`ha mission stop`, `ha mission complete`, `ha mission pause`) raced against in-flight ticks.

Fix:
- New `MissionStore.withTickLock(missionId, fn, opts?)` helper polls acquireTickLock with backoff (5s deadline, 100ms intervals) and runs fn while holding the lock.
- `missionStop` + `missionComplete` + `suspendMission` wrap their critical state-mutation block in withTickLock so the watchdog tick can't advance currentNode after we mark the mission stopped/suspended.

Test mocks updated with no-op withTickLock; 254 tests pass.

Closes #430 #431