### PR TITLE
feat(agents): wire HARU_MISSION_TASK_ID env var into agent spawn (#407, #413)

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -105,6 +105,14 @@ export interface SpawnOptions {
 	testPlanPath?: string;
 	/** Mission workstream id propagated into agent env as HARU_WORKSTREAM_ID. */
 	workstreamId?: string;
+	/**
+	 * Mission tracker task id (e.g. `haru-1234`) for the parent mission, when this
+	 * spawn is part of a mission. Injected into agent env as HARU_MISSION_TASK_ID
+	 * so child agents can file follow-up issues with `--blockedBy "$HARU_MISSION_TASK_ID"`.
+	 * Caller MUST pre-guard with isRealTaskId() so the PENDING_SENTINEL never reaches
+	 * the agent env (#407, #413).
+	 */
+	missionTaskId?: string;
 }
 
 /** Result of a successful spawn. */
@@ -528,6 +536,7 @@ export function buildHaruAgentEnvForTest(
 	worktreePath: string,
 	taskId: string,
 	workstreamId: string | undefined,
+	missionTaskId?: string,
 ): Record<string, string> {
 	return {
 		...base,
@@ -536,6 +545,7 @@ export function buildHaruAgentEnvForTest(
 		HARU_WORKTREE_PATH: worktreePath,
 		HARU_TASK_ID: taskId,
 		...(workstreamId ? { HARU_WORKSTREAM_ID: workstreamId } : {}),
+		...(missionTaskId ? { HARU_MISSION_TASK_ID: missionTaskId } : {}),
 	};
 }
 
@@ -551,7 +561,8 @@ async function spawnHeadless(
 	overstoryDir: string,
 ): Promise<SpawnResult> {
 	const { sessionStore: store } = deps;
-	const { name, capability, taskId, parentAgent, depth, runId, workstreamId } = opts;
+	const { name, capability, taskId, parentAgent, depth, runId, workstreamId, missionTaskId } =
+		opts;
 
 	const directEnv = buildHaruAgentEnvForTest(
 		runtime.buildEnv(resolvedModel),
@@ -560,6 +571,7 @@ async function spawnHeadless(
 		worktreePath,
 		taskId,
 		workstreamId,
+		missionTaskId,
 	);
 
 	if (!runtime.buildDirectSpawn) {
@@ -642,7 +654,8 @@ async function spawnInteractive(
 	overstoryDir: string,
 ): Promise<SpawnResult> {
 	const { sessionStore: store, config, tmux } = deps;
-	const { name, capability, taskId, parentAgent, depth, runId, workstreamId } = opts;
+	const { name, capability, taskId, parentAgent, depth, runId, workstreamId, missionTaskId } =
+		opts;
 
 	// 11c. Preflight: verify tmux is available
 	await tmux.ensureTmuxAvailable();
@@ -658,6 +671,7 @@ async function spawnInteractive(
 		worktreePath,
 		taskId,
 		workstreamId,
+		missionTaskId,
 	);
 	const spawnCmd = runtime.buildSpawnCommand({
 		model: resolvedModel.model,

--- a/src/commands/sling.ts
+++ b/src/commands/sling.ts
@@ -743,6 +743,7 @@ export async function slingCommand(
 	let missionSlug: string | undefined;
 	let missionArtifactRoot: string | undefined;
 	let missionTier: import("../missions/types.ts").MissionTier | null = null;
+	let missionTaskId: string | undefined;
 	if (missionContext) {
 		const missionStore = createMissionStore(join(overstoryDir, "sessions.db"));
 		try {
@@ -750,6 +751,13 @@ export async function slingCommand(
 			missionSlug = mission?.slug;
 			missionArtifactRoot = mission?.artifactRoot ?? undefined;
 			missionTier = mission?.tier ?? null;
+			// Inject the parent mission's tracker task id into agent env as
+			// HARU_MISSION_TASK_ID (#407, #413). Guard with isRealTaskId so the
+			// PENDING_SENTINEL placeholder never reaches the agent.
+			if (mission?.taskId) {
+				const { isRealTaskId } = await import("../missions/task-id.ts");
+				if (isRealTaskId(mission.taskId)) missionTaskId = mission.taskId;
+			}
 		} finally {
 			missionStore.close();
 		}
@@ -1138,6 +1146,7 @@ export async function slingCommand(
 			architecturePath: resolvedArchitecturePath,
 			testPlanPath: resolvedTestPlanPath,
 			workstreamId,
+			missionTaskId,
 		});
 
 		// Auto-start watchdog so every sling keeps the Tier 0 daemon alive


### PR DESCRIPTION
Final piece of haru-db98 auto-issue-link.

Child agents spawned inside a mission now receive `HARU_MISSION_TASK_ID` env var = parent mission's tracker task id, so they can file follow-up issues with `--blockedBy "$HARU_MISSION_TASK_ID"`.

## Changes
- `src/agents/spawn.ts` `SpawnOptions`: new `missionTaskId?: string` field
- `buildHaruAgentEnvForTest`: appends HARU_MISSION_TASK_ID when set
- `spawnHeadless` + `spawnViaTmux`: thread `missionTaskId` through env builder
- `src/commands/sling.ts`: look up active mission's taskId, guard via `isRealTaskId` so PENDING_SENTINEL never leaks into agent env (D-17)

## Verified
- bun test src/agents/spawn.test.ts src/commands/sling.test.ts → 182 pass, 0 fail

Closes #407 #413