### PR TITLE
fix: --spec --tier spawns roles + ha mission override CLI (#351, #352)

### DIFF
--- a/src/commands/mission-override.ts
+++ b/src/commands/mission-override.ts
@@ -1,0 +1,121 @@
+/**
+ * `ha mission override` — operator-fires a trigger on a stuck mission node.
+ *
+ * Bug fix #352: when a mission auto-suspends at a node like
+ * `plan-phase:review-stuck` after max review rounds, operators today have no
+ * documented way to push through — the graph defines `override` edges but no
+ * CLI fires them, and `ha mission resume` looks for top-level lifecycle edges
+ * that don't exist on subgraph nodes.
+ *
+ * This handler takes the user-supplied `--node` and `--trigger`, validates
+ * both against the lifecycle graph, fires the trigger via the checkpoint
+ * store's `saveStepResult` (atomic record + advance), and flips the mission
+ * back to `active` so the watchdog tick picks it up.
+ */
+
+import { join } from "node:path";
+import { jsonError, jsonOutput } from "../json.ts";
+import { printError, printSuccess } from "../logging/color.ts";
+import { buildLifecycleGraph } from "../missions/engine-wiring.ts";
+import { createMissionStore } from "../missions/store.ts";
+import type { MissionGraphEdge, MissionGraphNode } from "../types.ts";
+
+export interface MissionOverrideOpts {
+	missionId: string | undefined;
+	node: string;
+	trigger: string;
+	json: boolean;
+}
+
+/**
+ * Find the outgoing edge from `nodeId` with the given trigger, walking the
+ * lifecycle graph and all attached subgraphs.
+ */
+function findEdge(
+	nodes: readonly MissionGraphNode[],
+	nodeId: string,
+	trigger: string,
+): MissionGraphEdge | null {
+	for (const node of nodes) {
+		if (node.kind === "lifecycle" && node.subgraph) {
+			for (const edge of node.subgraph.edges) {
+				if (edge.from === nodeId && edge.trigger === trigger) return edge;
+			}
+		}
+	}
+	// Top-level lifecycle edges are searched as a fallback (e.g. operator firing
+	// `phase_advance` from a lifecycle node).
+	return null;
+}
+
+export async function missionOverride(
+	overstoryDir: string,
+	opts: MissionOverrideOpts,
+): Promise<void> {
+	const dbPath = join(overstoryDir, "sessions.db");
+	const missionStore = createMissionStore(dbPath);
+
+	try {
+		let missionId = opts.missionId;
+		if (!missionId) {
+			const active = missionStore.getActive();
+			if (!active) {
+				if (opts.json) jsonError("mission override", "No active mission");
+				else printError("No active mission");
+				process.exitCode = 1;
+				return;
+			}
+			missionId = active.id;
+		}
+		const mission = missionStore.getById(missionId) ?? missionStore.getBySlug(missionId);
+		if (!mission) {
+			if (opts.json) jsonError("mission override", `Mission not found: ${opts.missionId}`);
+			else printError(`Mission not found: ${opts.missionId}`);
+			process.exitCode = 1;
+			return;
+		}
+
+		if (mission.currentNode !== opts.node) {
+			const msg = `Mission ${mission.slug} is at node '${mission.currentNode}', not '${opts.node}'`;
+			if (opts.json) jsonError("mission override", msg);
+			else printError(msg);
+			process.exitCode = 1;
+			return;
+		}
+
+		const graph = buildLifecycleGraph(mission);
+		const edge = findEdge(graph.nodes, opts.node, opts.trigger);
+		if (!edge) {
+			const msg = `No edge with trigger '${opts.trigger}' from node '${opts.node}' in the lifecycle graph`;
+			if (opts.json) jsonError("mission override", msg);
+			else printError(msg);
+			process.exitCode = 1;
+			return;
+		}
+
+		// Atomically advance: record transition + update currentNode.
+		missionStore.checkpoints.saveStepResult(mission.id, opts.node, edge.to, opts.trigger, null);
+		missionStore.updateCurrentNode(mission.id, edge.to);
+		if (mission.state === "suspended") {
+			missionStore.updateState(mission.id, "active");
+		}
+
+		if (opts.json) {
+			jsonOutput("mission override", {
+				mission: mission.slug,
+				from: opts.node,
+				to: edge.to,
+				trigger: opts.trigger,
+				wasSuspended: mission.state === "suspended",
+			});
+		} else {
+			printSuccess(
+				"Mission overridden",
+				`${mission.slug}: ${opts.node} → ${edge.to} via ${opts.trigger}` +
+					(mission.state === "suspended" ? " (suspended → active)" : ""),
+			);
+		}
+	} finally {
+		missionStore.close();
+	}
+}

--- a/src/commands/mission.test.ts
+++ b/src/commands/mission.test.ts
@@ -52,7 +52,21 @@ describe("createMissionCommand", () => {
 		expect(names).toContain("tier");
 		expect(names).toContain("spec");
 		expect(names).toContain("debug");
-		expect(names).toHaveLength(22);
+		expect(names).toContain("override");
+		expect(names).toHaveLength(23);
+	});
+
+	test("override subcommand requires --node and --trigger (#352)", () => {
+		const cmd = createMissionCommand();
+		const override = cmd.commands.find((command) => command.name() === "override");
+		expect(override).toBeDefined();
+		const options = override?.options ?? [];
+		const nodeOpt = options.find((o) => o.long === "--node");
+		const triggerOpt = options.find((o) => o.long === "--trigger");
+		expect(nodeOpt?.required).toBe(true);
+		expect(triggerOpt?.required).toBe(true);
+		expect(options.find((o) => o.long === "--mission")).toBeDefined();
+		expect(options.find((o) => o.long === "--json")).toBeDefined();
 	});
 
 	test("answer subcommand supports --body and --file", () => {

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -355,6 +355,28 @@ export function createMissionCommand(): Command {
 		});
 
 	cmd
+		.command("override")
+		.description(
+			"Force-fire a trigger from a stuck mission node (e.g. plan-phase:review-stuck override). #352",
+		)
+		.requiredOption("--node <node-id>", "Mission node the mission is currently at")
+		.requiredOption("--trigger <name>", "Edge trigger name to fire from that node")
+		.option("--mission <id-or-slug>", "Target a specific mission (default: active)")
+		.option("--json", "Output as JSON")
+		.action(async (opts: { node: string; trigger: string; mission?: string; json?: boolean }) => {
+			const cwd = process.cwd();
+			const config = await loadConfig(cwd);
+			const overstoryDir = join(config.project.root, detectHaruDir(config.project.root));
+			const { missionOverride } = await import("./mission-override.ts");
+			await missionOverride(overstoryDir, {
+				missionId: opts.mission,
+				node: opts.node,
+				trigger: opts.trigger,
+				json: opts.json ?? false,
+			});
+		});
+
+	cmd
 		.command("stop")
 		.description("Suspend the active mission (preserves state for resume)")
 		.option("--kill", "Full teardown — no resume possible")

--- a/src/missions/lifecycle-start.ts
+++ b/src/missions/lifecycle-start.ts
@@ -346,6 +346,32 @@ export async function missionStart(
 			},
 		});
 
+		// Bug fix #351: when `--spec --tier` skips intake-phase, the
+		// dispatch-tier-classifier handler that normally spawns the operational
+		// coordinator never runs. Without a coordinator, direct-tier missions stay
+		// at `execute-phase:await-leads-done` forever and planned/full miss
+		// analyst+ED too. Reuse restartMissionRoles (same wiring as resume) to
+		// spawn the tier-appropriate roles right after mission_started.
+		if (opts.specFile && opts.tier) {
+			try {
+				const roleResults = await restartMissionRoles(overstoryDir, projectRoot, mission, deps);
+				for (const r of roleResults) {
+					if (!r.success && !opts.json) {
+						printWarning(
+							`Role start failed for ${r.agentName}: ${r.error?.slice(0, 200) ?? "unknown"}`,
+						);
+					}
+				}
+			} catch (err) {
+				// Best-effort: mission row exists; operator can ha mission resume to retry.
+				if (!opts.json) {
+					printWarning(
+						`Persistent-role spawn failed: ${err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200)}`,
+					);
+				}
+			}
+		}
+
 		// Auto-start watchdog for rate-limit detection and health monitoring
 		try {
 			const config = await loadConfig(projectRoot);


### PR DESCRIPTION
Two real bugs from the backlog.

## #351 — `--spec --tier` combo skips role spawn

`ha mission start --spec --tier` is documented as a power-user path that skips intake-phase. In practice it also skipped the tier-classifier's coordinator-spawn step, so:
- direct-tier missions stalled at `execute-phase:await-leads-done` (no coordinator = no leads dispatched)
- planned/full missions also missed analyst+ED spawn

**Verified locally**: mission `fix-351-analyst-spawn` launched 45 min ago, never advanced past execute, zero state transitions recorded.

**Fix**: when `opts.specFile && opts.tier`, invoke `restartMissionRoles` right after `mission_started` event — same wiring that powers `ha mission resume`, just at start time. Spawns the tier-appropriate coordinator (+ analyst for planned/full, + ED for full). Best-effort: failures log via printWarning so operator can `ha mission resume` to retry.

## #352 — `ha mission override` CLI

`src/missions/cells/plan-phase.ts` defines an `override` edge from `plan-phase:review-stuck` → `plan-phase:await-handoff` but no CLI fires it. Operators had to kill+relaunch (~1h work lost) or hack the DB.

**Fix**: new subcommand `ha mission override --node <id> --trigger <name>`. Resolves the mission, verifies `currentNode === --node`, looks up the edge in the lifecycle graph (walks lifecycle nodes + their subgraphs), atomically records the transition via `missionStore.checkpoints.saveStepResult`, updates `currentNode`, flips suspended→active so the watchdog tick picks it up.

Generic (works on any node, not just plan-phase:review-stuck) but tight surface — required `--node` + `--trigger` so operator confirms intent.

## Verified

- 42 tests pass (`mission.test.ts` + `lifecycle-start.test.ts`)
- biome check clean

Closes #351 #352