### PR TITLE
test(config): tests for watchdog rpcTimeoutMs/triageTimeoutMs/maxEscalationLevel/triageMaxConcurrent (#385)

### DIFF
--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -60,6 +60,13 @@ describe("config-schema constants", () => {
 		expect(KNOWN_FIELDS.watchdog.has("tier1IntervalMs")).toBe(false);
 	});
 
+	test("KNOWN_FIELDS.watchdog includes all 4 new configurable timeout/cap keys", () => {
+		expect(KNOWN_FIELDS.watchdog.has("rpcTimeoutMs")).toBe(true);
+		expect(KNOWN_FIELDS.watchdog.has("triageTimeoutMs")).toBe(true);
+		expect(KNOWN_FIELDS.watchdog.has("maxEscalationLevel")).toBe(true);
+		expect(KNOWN_FIELDS.watchdog.has("triageMaxConcurrent")).toBe(true);
+	});
+
 	test("KNOWN_FIELDS.providerItem covers all provider fields", () => {
 		expect(KNOWN_FIELDS.providerItem.has("type")).toBe(true);
 		expect(KNOWN_FIELDS.providerItem.has("baseUrl")).toBe(true);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -932,6 +932,28 @@ project:
 `);
 		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
 	});
+
+	test("rejects watchdog.maxEscalationLevel out of [1,5] or non-integer", async () => {
+		await writeConfig("watchdog:\n  maxEscalationLevel: 0\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+
+		await writeConfig("watchdog:\n  maxEscalationLevel: 6\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+
+		await writeConfig("watchdog:\n  maxEscalationLevel: 2.5\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+	});
+
+	test("rejects watchdog.triageMaxConcurrent out of [1,10] or non-integer", async () => {
+		await writeConfig("watchdog:\n  triageMaxConcurrent: 0\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+
+		await writeConfig("watchdog:\n  triageMaxConcurrent: 11\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+
+		await writeConfig("watchdog:\n  triageMaxConcurrent: 1.5\n");
+		await expect(loadConfig(tempDir)).rejects.toThrow(ValidationError);
+	});
 });
 
 describe("resolveProjectRoot", () => {
@@ -1292,6 +1314,13 @@ describe("DEFAULT_CONFIG", () => {
 		expect(DEFAULT_CONFIG.watchdog.tier0IntervalMs).toBe(30_000);
 		expect(DEFAULT_CONFIG.watchdog.staleThresholdMs).toBe(300_000);
 		expect(DEFAULT_CONFIG.watchdog.zombieThresholdMs).toBe(600_000);
+	});
+
+	test("has correct defaults for new watchdog knobs (#380, #381, #382, #384)", () => {
+		expect(DEFAULT_CONFIG.watchdog.rpcTimeoutMs).toBe(5_000);
+		expect(DEFAULT_CONFIG.watchdog.triageTimeoutMs).toBe(30_000);
+		expect(DEFAULT_CONFIG.watchdog.maxEscalationLevel).toBe(3);
+		expect(DEFAULT_CONFIG.watchdog.triageMaxConcurrent).toBe(2);
 	});
 
 	test("includes default qualityGates", () => {


### PR DESCRIPTION
Mission-produced (fix-385-v3, builder commit b4f1654a).

Adds focused tests for the 4 watchdog config knobs landed in #435 + #438:
- DEFAULT_CONFIG assertions for rpcTimeoutMs=5000, triageTimeoutMs=30000, maxEscalationLevel=3, triageMaxConcurrent=2
- Validation tests for maxEscalationLevel range [1,5] (rejects 0, 6, non-integer 2.5)
- Validation tests for triageMaxConcurrent range [1,10] (rejects 0, 11, non-integer)
- KNOWN_FIELDS.watchdog includes all 4 new keys

122 tests pass; biome clean.

Note: pr-phase didn't auto-create this PR because the running watchdog daemon at mission time predated PRs #434/#438/#439 (stale module cache). Daemon restarted post-mission to pick up the fixes.

Closes #385