### PR TITLE
fix(watchdog): auto-complete agents stuck in idle loop after result mail (#109)

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -87,6 +87,7 @@ export const KNOWN_FIELDS = {
 		"triageTimeoutMs",
 		"maxEscalationLevel",
 		"triageMaxConcurrent",
+		"idleLoopThresholdMs",
 	]),
 	logging: new Set(["verbose", "redactSecrets"]),
 	coordinator: new Set(["autoPull", "exitTriggers"]),

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -149,6 +149,7 @@ export interface OverstoryConfig {
 		triageTimeoutMs?: number; // Per-call timeout for Tier 1 AI triage Claude spawn (default 30000, must be < tier0IntervalMs) — #381
 		maxEscalationLevel?: number; // Maximum escalation level the daemon advances through (default 3, range 1-5) — #382
 		triageMaxConcurrent?: number; // Concurrent Tier 1 triage spawns allowed per tick (default 2, range 1-10) — #384
+		idleLoopThresholdMs?: number; // #109: auto-complete agents that sent result mail but loop instead of exiting (default 300_000, range 60_000-3_600_000)
 	};
 	models: Partial<Record<string, ModelRef>>;
 	logging: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,7 @@ export const DEFAULT_CONFIG: OverstoryConfig = {
 		triageTimeoutMs: 30_000, // Tier 1 AI triage Claude-spawn timeout (#381)
 		maxEscalationLevel: 3, // Escalation ladder ceiling (#382)
 		triageMaxConcurrent: 2, // Concurrent Tier 1 triage spawns per tick (#384)
+		idleLoopThresholdMs: 300_000, // #109: auto-complete after result mail + idle loop > 5 min
 	},
 	mission: {
 		planReview: {
@@ -377,6 +378,20 @@ function validateConfig(config: OverstoryConfig): void {
 				field: "watchdog.triageMaxConcurrent",
 				value: n,
 			});
+		}
+	}
+
+	// #109: idleLoopThresholdMs must be in [60_000, 3_600_000] when set.
+	if (config.watchdog.idleLoopThresholdMs !== undefined) {
+		const ms = config.watchdog.idleLoopThresholdMs;
+		if (!Number.isFinite(ms) || ms < 60_000 || ms > 3_600_000) {
+			throw new ValidationError(
+				"watchdog.idleLoopThresholdMs must be a number in [60000, 3600000]",
+				{
+					field: "watchdog.idleLoopThresholdMs",
+					value: ms,
+				},
+			);
 		}
 	}
 

--- a/src/watchdog/daemon.test.ts
+++ b/src/watchdog/daemon.test.ts
@@ -14,6 +14,7 @@
  * mx-56558b for background.
  */
 
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, writeFileSync } from "node:fs";
 import { mkdir, mkdtemp } from "node:fs/promises";
@@ -3978,5 +3979,155 @@ describe("gap detection", () => {
 		expect(stallEvents.length).toBe(0);
 
 		eventStore.close();
+	});
+});
+
+// === #109: idle-loop auto-complete tests ===
+
+describe("idle-loop auto-complete (#109)", () => {
+	/**
+	 * Insert a mail_sent event with a backdated created_at. The default insert
+	 * stamps "now" via SQLite, so we drop down to raw SQL to backdate. Uses
+	 * createEventStore() first to ensure the schema is initialized.
+	 */
+	function insertBackdatedResultMail(dbPath: string, agentName: string, ageMs: number): void {
+		// Ensure schema exists.
+		const init = createEventStore(dbPath);
+		init.close();
+		const db = new Database(dbPath);
+		try {
+			const createdAt = new Date(Date.now() - ageMs).toISOString();
+			db.prepare(
+				`INSERT INTO events
+					(run_id, agent_name, session_id, event_type, tool_name, tool_args,
+					 tool_duration_ms, level, data, created_at)
+				VALUES (NULL, $agent_name, NULL, 'mail_sent', NULL, NULL, NULL, 'info',
+					$data, $created_at)`,
+			).run({
+				$agent_name: agentName,
+				$data: JSON.stringify({ type: "result", subject: "task done" }),
+				$created_at: createdAt,
+			});
+		} finally {
+			db.close();
+		}
+	}
+
+	test("auto-completes waiting agent when result mail sent > idleLoopThresholdMs ago", async () => {
+		const session = makeSession({
+			agentName: "looping-scout",
+			tmuxSession: "haru-looping-scout",
+			capability: "scout",
+			state: "waiting",
+			// startedAt well in the past so the backdated event is in-session.
+			startedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		writeSessionsToStore(tempRoot, [session]);
+
+		// Result mail sent 10 minutes ago — well past the 5-minute default threshold.
+		insertBackdatedResultMail(
+			join(tempRoot, ".overstory", "events.db"),
+			"looping-scout",
+			10 * 60_000,
+		);
+
+		await runDaemonTick({
+			root: tempRoot,
+			...THRESHOLDS,
+			_tmux: tmuxAllAlive(),
+			_triage: triageAlways("extend"),
+			// Pane does NOT reach ready prompt — this is the looping-scout scenario.
+			_capturePaneContent: async () => "Loop 47 — No change. Awaiting new task assignment.",
+		});
+
+		const reloaded = readSessionsFromStore(tempRoot);
+		expect(reloaded[0]?.state).toBe("completed");
+	});
+
+	test("does NOT auto-complete waiting agent when no result mail was sent", async () => {
+		const session = makeSession({
+			agentName: "no-result-scout",
+			tmuxSession: "haru-no-result-scout",
+			capability: "scout",
+			state: "waiting",
+			startedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		writeSessionsToStore(tempRoot, [session]);
+
+		// No events at all — guarantees no result mail.
+
+		await runDaemonTick({
+			root: tempRoot,
+			...THRESHOLDS,
+			_tmux: tmuxAllAlive(),
+			_triage: triageAlways("extend"),
+			_capturePaneContent: async () => "Loop 5 — Awaiting new task assignment.",
+		});
+
+		const reloaded = readSessionsFromStore(tempRoot);
+		expect(reloaded[0]?.state).toBe("waiting");
+	});
+
+	test("does NOT auto-complete waiting agent when result mail sent < threshold", async () => {
+		const session = makeSession({
+			agentName: "fresh-result-scout",
+			tmuxSession: "haru-fresh-result-scout",
+			capability: "scout",
+			state: "waiting",
+			startedAt: new Date(Date.now() - 30 * 60_000).toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		writeSessionsToStore(tempRoot, [session]);
+
+		// Result mail sent only 1 minute ago — well below the 5-minute default threshold.
+		insertBackdatedResultMail(
+			join(tempRoot, ".overstory", "events.db"),
+			"fresh-result-scout",
+			60_000,
+		);
+
+		await runDaemonTick({
+			root: tempRoot,
+			...THRESHOLDS,
+			_tmux: tmuxAllAlive(),
+			_triage: triageAlways("extend"),
+			_capturePaneContent: async () => "Loop 1 — Awaiting new task assignment.",
+		});
+
+		const reloaded = readSessionsFromStore(tempRoot);
+		expect(reloaded[0]?.state).toBe("waiting");
+	});
+
+	test("does NOT auto-complete persistent agents (coordinator) even when result mail is stale", async () => {
+		const session = makeSession({
+			agentName: "coordinator-99",
+			tmuxSession: "haru-coordinator-99",
+			capability: "coordinator",
+			state: "waiting",
+			startedAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+			lastActivity: new Date().toISOString(),
+		});
+		writeSessionsToStore(tempRoot, [session]);
+
+		// Result mail sent 30 minutes ago — well past the default threshold.
+		insertBackdatedResultMail(
+			join(tempRoot, ".overstory", "events.db"),
+			"coordinator-99",
+			30 * 60_000,
+		);
+
+		await runDaemonTick({
+			root: tempRoot,
+			...THRESHOLDS,
+			_tmux: tmuxAllAlive(),
+			_triage: triageAlways("extend"),
+			_capturePaneContent: async () => "Loop 99 — Awaiting new task assignment.",
+		});
+
+		const reloaded = readSessionsFromStore(tempRoot);
+		// Persistent capability is exempt — must stay waiting.
+		expect(reloaded[0]?.state).toBe("waiting");
 	});
 });

--- a/src/watchdog/daemon.ts
+++ b/src/watchdog/daemon.ts
@@ -339,6 +339,45 @@ function hasAutoCompleteSignal(
 }
 
 /**
+ * Time (ms) since the agent's most recent `mail_sent` event with `type=result`.
+ * Returns null when no such event is found in the current session window.
+ *
+ * #109: lets the watchdog catch the "result mail sent but agent kept looping" pattern,
+ * where the agent never reaches a ready prompt so `hasAutoCompleteSignal` alone isn't enough.
+ */
+function timeSinceLastResultMail(
+	eventStore: EventStore | null,
+	agentName: string,
+	sessionStartedAt?: string,
+): number | null {
+	if (!eventStore) return null;
+	try {
+		const events = eventStore.getByAgent(agentName);
+		// Walk from newest to oldest. Cap to last 100 events — same short-circuit
+		// rationale as hasAutoCompleteSignal/hasIterationSignal but with a larger
+		// window because the result mail can be older than the 20-event ceiling
+		// those siblings use (we care about "any result mail this session").
+		const scanLimit = Math.max(0, events.length - 100);
+		for (let i = events.length - 1; i >= scanLimit; i--) {
+			const event = events[i];
+			if (!event || event.eventType !== "mail_sent" || !event.data) continue;
+			if (sessionStartedAt && event.createdAt < sessionStartedAt) continue;
+			try {
+				const data = JSON.parse(event.data) as { type?: string };
+				if (data.type === "result") {
+					return Date.now() - new Date(event.createdAt).getTime();
+				}
+			} catch {
+				/* ignore */
+			}
+		}
+	} catch {
+		/* ignore */
+	}
+	return null;
+}
+
+/**
  * Check if agent SENT an iteration signal (worker_done, merge_ready).
  * Queries events.db for mail_sent events sent BY this agent with type in ITERATION_SIGNALS.
  */
@@ -385,6 +424,7 @@ function shouldCompleteAgent(params: {
 	eventStore: EventStore | null;
 	store: { getByName: (name: string) => AgentSession | null; getAll: () => AgentSession[] };
 	overstoryDir: string;
+	idleLoopThresholdMs?: number;
 }): { complete: boolean; reason: string } {
 	const { session, tmuxAlive, atReadyPrompt, eventStore, store, overstoryDir } = params;
 
@@ -413,6 +453,17 @@ function shouldCompleteAgent(params: {
 	// 2. Auto-complete signal (result) + at ready prompt
 	if (atReadyPrompt && hasAutoCompleteSignal(eventStore, session.agentName, session.startedAt)) {
 		return { complete: true, reason: "auto-complete: result signal + at ready prompt" };
+	}
+
+	// #109: catch the "result mail sent but agent kept looping" pattern.
+	// Persistent agents already returned early above.
+	const idleLoopMs = timeSinceLastResultMail(eventStore, session.agentName, session.startedAt);
+	const threshold = params.idleLoopThresholdMs ?? 300_000;
+	if (idleLoopMs !== null && idleLoopMs > threshold) {
+		return {
+			complete: true,
+			reason: `auto-complete: result mail sent ${Math.floor(idleLoopMs / 60_000)}m ago + idle loop`,
+		};
 	}
 
 	// 3. Iteration signal (worker_done / merge_ready) → parent decides
@@ -1589,6 +1640,7 @@ export async function runDaemonTick(options: DaemonOptions): Promise<void> {
 					eventStore,
 					store,
 					overstoryDir,
+					idleLoopThresholdMs: options.config?.watchdog?.idleLoopThresholdMs,
 				});
 				if (completion.complete) {
 					reconcileSessionToCompleted({


### PR DESCRIPTION
Closes #109. Adds idleLoopThresholdMs config (default 5 min) and a new shouldCompleteAgent branch that fires when an agent sent the result mail more than threshold ago — catching the 'Loop N — No change. Awaiting new task assignment' pattern that doesn't trigger the existing atReadyPrompt-based auto-complete. Persistent agents stay excluded. 217 tests pass; reviewer APPROVED.