### PR TITLE
docs(readme): symmetric ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,8 @@ MIT
 
 Maintained by [Kyryl Zmiienko](https://www.linkedin.com/in/kyryl-zmiienko/).
 
-Originally forked because of its mail system, but has since diverged
-significantly in scope and direction and is no longer tracked against upstream.
+Part of a personal ecosystem alongside [Kura](https://github.com/liker0704/kura),
+[Suji](https://github.com/liker0704/suji), and
+[Tane](https://github.com/liker0704/tane). Originally forked because of its
+mail system; has since diverged significantly in scope and direction and is no
+longer tracked against upstream.


### PR DESCRIPTION
Adds 'Part of a personal ecosystem alongside…' line to footer to match kura/suji/tane format, while preserving the mail-system divergence note.