### PR TITLE
fix(missions): inject HARU_MISSION_ID/SLUG env vars to prevent slug contamination (#461)

### DIFF
--- a/src/agents/spawn.test.ts
+++ b/src/agents/spawn.test.ts
@@ -457,6 +457,68 @@ describe("createSpawnService", () => {
 		});
 	});
 
+	describe("HARU_MISSION_ID / HARU_MISSION_SLUG env propagation (#461)", () => {
+		test("env includes both when missionId and missionSlug are set", () => {
+			const env = buildHaruAgentEnvForTest(
+				{},
+				"builder-test",
+				null,
+				"/tmp/wt",
+				"task-1",
+				undefined,
+				undefined,
+				"mission-1780",
+				"adr-342-pr-default",
+			);
+			expect(env.HARU_MISSION_ID).toBe("mission-1780");
+			expect(env.HARU_MISSION_SLUG).toBe("adr-342-pr-default");
+		});
+
+		test("env omits both when missionId and missionSlug are undefined", () => {
+			const env = buildHaruAgentEnvForTest(
+				{},
+				"builder-test",
+				null,
+				"/tmp/wt",
+				"task-1",
+				undefined,
+				undefined,
+			);
+			expect("HARU_MISSION_ID" in env).toBe(false);
+			expect("HARU_MISSION_SLUG" in env).toBe(false);
+		});
+
+		test("env includes only the set value when one is missing", () => {
+			const envIdOnly = buildHaruAgentEnvForTest(
+				{},
+				"a",
+				null,
+				"/wt",
+				"t",
+				undefined,
+				undefined,
+				"mission-x",
+				undefined,
+			);
+			expect(envIdOnly.HARU_MISSION_ID).toBe("mission-x");
+			expect("HARU_MISSION_SLUG" in envIdOnly).toBe(false);
+
+			const envSlugOnly = buildHaruAgentEnvForTest(
+				{},
+				"a",
+				null,
+				"/wt",
+				"t",
+				undefined,
+				undefined,
+				undefined,
+				"slug-only",
+			);
+			expect("HARU_MISSION_ID" in envSlugOnly).toBe(false);
+			expect(envSlugOnly.HARU_MISSION_SLUG).toBe("slug-only");
+		});
+	});
+
 	describe("project context loading", () => {
 		// These tests verify that context loading is non-fatal.
 		// spawn() always fails at createWorktree in this test context (no real git repo),

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -97,6 +97,13 @@ export interface SpawnOptions {
 	json: boolean;
 	/** Mission slug for worktree isolation. */
 	missionSlug?: string;
+	/**
+	 * Mission ID for env injection. Allows child agents to identify their own
+	 * mission deterministically (HARU_MISSION_ID + HARU_MISSION_SLUG) instead of
+	 * reading the shared `.overstory/current-mission.txt` pointer, which is
+	 * unsafe under parallel missions (#461).
+	 */
+	missionId?: string;
 	/** TDD mode for Flash Quality pipeline. */
 	tddMode?: TddMode;
 	/** Path to architecture.md for Flash Quality. */
@@ -537,6 +544,8 @@ export function buildHaruAgentEnvForTest(
 	taskId: string,
 	workstreamId: string | undefined,
 	missionTaskId?: string,
+	missionId?: string,
+	missionSlug?: string,
 ): Record<string, string> {
 	return {
 		...base,
@@ -546,6 +555,8 @@ export function buildHaruAgentEnvForTest(
 		HARU_TASK_ID: taskId,
 		...(workstreamId ? { HARU_WORKSTREAM_ID: workstreamId } : {}),
 		...(missionTaskId ? { HARU_MISSION_TASK_ID: missionTaskId } : {}),
+		...(missionId ? { HARU_MISSION_ID: missionId } : {}),
+		...(missionSlug ? { HARU_MISSION_SLUG: missionSlug } : {}),
 	};
 }
 
@@ -561,8 +572,18 @@ async function spawnHeadless(
 	overstoryDir: string,
 ): Promise<SpawnResult> {
 	const { sessionStore: store } = deps;
-	const { name, capability, taskId, parentAgent, depth, runId, workstreamId, missionTaskId } =
-		opts;
+	const {
+		name,
+		capability,
+		taskId,
+		parentAgent,
+		depth,
+		runId,
+		workstreamId,
+		missionTaskId,
+		missionId,
+		missionSlug,
+	} = opts;
 
 	const directEnv = buildHaruAgentEnvForTest(
 		runtime.buildEnv(resolvedModel),
@@ -572,6 +593,8 @@ async function spawnHeadless(
 		taskId,
 		workstreamId,
 		missionTaskId,
+		missionId,
+		missionSlug,
 	);
 
 	if (!runtime.buildDirectSpawn) {
@@ -654,8 +677,18 @@ async function spawnInteractive(
 	overstoryDir: string,
 ): Promise<SpawnResult> {
 	const { sessionStore: store, config, tmux } = deps;
-	const { name, capability, taskId, parentAgent, depth, runId, workstreamId, missionTaskId } =
-		opts;
+	const {
+		name,
+		capability,
+		taskId,
+		parentAgent,
+		depth,
+		runId,
+		workstreamId,
+		missionTaskId,
+		missionId,
+		missionSlug,
+	} = opts;
 
 	// 11c. Preflight: verify tmux is available
 	await tmux.ensureTmuxAvailable();
@@ -672,6 +705,8 @@ async function spawnInteractive(
 		taskId,
 		workstreamId,
 		missionTaskId,
+		missionId,
+		missionSlug,
 	);
 	const spawnCmd = runtime.buildSpawnCommand({
 		model: resolvedModel.model,

--- a/src/commands/sling.ts
+++ b/src/commands/sling.ts
@@ -736,7 +736,15 @@ export async function slingCommand(
 	const config = await loadConfig(cwd);
 	const resolvedBackend = await resolveBackend(config.taskTracker.backend, config.project.root);
 	const overstoryDir = join(config.project.root, detectHaruDir(config.project.root));
-	const missionContext = await resolveActiveMissionContext(overstoryDir);
+	// Prefer env vars when this sling call is initiated by a child agent (#461):
+	// the agent's spawn injected HARU_MISSION_ID/HARU_MISSION_SLUG, which is the
+	// only reliable per-process identifier under parallel missions. The shared
+	// `.overstory/current-mission.txt` pointer can flip to whichever mission
+	// started last and is unsafe for agent self-identification.
+	const envMissionId = process.env.HARU_MISSION_ID;
+	const missionContext = envMissionId
+		? { missionId: envMissionId, runId: process.env.HARU_RUN_ID ?? null }
+		: await resolveActiveMissionContext(overstoryDir);
 	const hasMission = missionContext !== null;
 
 	// Resolve mission slug, artifact root, and tier for resource isolation and capability resolution
@@ -1142,6 +1150,7 @@ export async function slingCommand(
 			skipTaskCheck,
 			json: opts.json ?? false,
 			missionSlug,
+			missionId: missionContext?.missionId,
 			tddMode: resolvedTddMode,
 			architecturePath: resolvedArchitecturePath,
 			testPlanPath: resolvedTestPlanPath,


### PR DESCRIPTION
Closes #461.

## Summary

Parallel \`ha sling\` calls were picking up the wrong mission slug under parallel missions because \`resolveActiveMissionContext\` reads the shared \`.overstory/current-mission.txt\` pointer, which returns the last-started mission regardless of which agent is calling. Branch names ended up containing two slugs (\`haru/<mission-A>/builder-<mission-B>/...\`).

This caused the failure observed in PR #460 (mission \`adr-342-pr-default\` produced a branch named \`haru/adr-234-autonomy/builder-adr-342/haru-17ff\`).

## Fix

Inject \`HARU_MISSION_ID\` and \`HARU_MISSION_SLUG\` into each spawned agent's env (alongside the existing \`HARU_AGENT_NAME\`, \`HARU_TASK_ID\`, \`HARU_WORKSTREAM_ID\`). \`slingCommand\` prefers env vars and only falls back to the shared pointer when env is absent (operator-driven case).

## Changes

- \`src/agents/spawn.ts\` — add \`missionId\` to \`SpawnOptions\`; pass both \`missionId\` and \`missionSlug\` through \`buildHaruAgentEnvForTest\` to the env block; both spawn paths (headless + tmux) updated.
- \`src/commands/sling.ts\` — read \`HARU_MISSION_ID\` from env before consulting \`resolveActiveMissionContext\`; pass \`missionId\` to spawn.
- \`src/agents/spawn.test.ts\` — 3 new tests covering env var injection (both set, both unset, mixed).

## Tests

- \`bun test src/agents/spawn.test.ts\` — 15 pass (3 new)
- \`bun test src/commands/sling.test.ts\` — 170 pass
- \`biome check\` — clean