### PR TITLE
fix(missions): trust feature-branch tree + bypass session-branch in mission context (#462)

### DIFF
--- a/src/commands/merge.test.ts
+++ b/src/commands/merge.test.ts
@@ -661,6 +661,62 @@ merge:
 			const currentBranch = await runGitInDir(repoDir, ["symbolic-ref", "--short", "HEAD"]);
 			expect(currentBranch.trim()).toBe("explicit-target");
 		});
+
+		test("#462: HARU_MISSION_TASK_ID env bypasses stale session-branch.txt → targets canonicalBranch", async () => {
+			await setupProject(repoDir, defaultBranch);
+
+			// Create a stale session branch (simulating operator's leftover docs work)
+			await commitFile(repoDir, "src/base.ts", "base content");
+			await runGitInDir(repoDir, ["checkout", "-b", "fix/stale-operator-branch"]);
+			await commitFile(repoDir, "src/stale-marker.ts", "operator leftover");
+			await runGitInDir(repoDir, ["checkout", defaultBranch]);
+
+			// session-branch.txt points to the stale operator branch
+			await Bun.write(
+				join(repoDir, ".overstory", "session-branch.txt"),
+				"fix/stale-operator-branch\n",
+			);
+
+			// Create mission feature branch
+			const branchName = "haru/mission/builder-ws/bead-462-test";
+			await runGitInDir(repoDir, ["checkout", "-b", branchName]);
+			await commitFile(repoDir, `src/${branchName}.ts`, "mission content");
+			await runGitInDir(repoDir, ["checkout", defaultBranch]);
+
+			let output = "";
+			const originalWrite = process.stdout.write.bind(process.stdout);
+			process.stdout.write = (chunk: unknown): boolean => {
+				output += String(chunk);
+				return true;
+			};
+
+			// Simulate mission-spawned coordinator: HARU_MISSION_TASK_ID is set
+			const savedEnv = process.env.HARU_MISSION_TASK_ID;
+			process.env.HARU_MISSION_TASK_ID = "haru-462";
+			try {
+				await mergeCommand({ branch: branchName, json: true });
+			} finally {
+				process.stdout.write = originalWrite;
+				if (savedEnv === undefined) {
+					delete process.env.HARU_MISSION_TASK_ID;
+				} else {
+					process.env.HARU_MISSION_TASK_ID = savedEnv;
+				}
+			}
+
+			const parsed = JSON.parse(output);
+			expect(parsed.success).toBe(true);
+
+			// Critical: merge MUST land on canonicalBranch (defaultBranch), NOT on the stale
+			// session branch. This is the root-cause fix for #462.
+			const currentBranch = await runGitInDir(repoDir, ["symbolic-ref", "--short", "HEAD"]);
+			expect(currentBranch.trim()).toBe(defaultBranch);
+
+			// Verify the mission's commits did NOT leak into the stale operator branch.
+			await runGitInDir(repoDir, ["checkout", "fix/stale-operator-branch"]);
+			const leaked = await Bun.file(join(repoDir, `src/${branchName}.ts`)).exists();
+			expect(leaked).toBe(false);
+		});
 	});
 
 	describe("conflict handling", () => {

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -151,9 +151,21 @@ export async function mergeCommand(opts: MergeOptions): Promise<void> {
 	const cwd = process.cwd();
 	const config = await loadConfig(cwd);
 
-	// Resolution chain: --into flag > session-start branch > config canonicalBranch
+	// Resolution chain: --into flag > session-start branch > config canonicalBranch.
+	//
+	// Bug fix #462: when running inside a mission context (HARU_MISSION_TASK_ID
+	// set by the spawn env), bypass `session-branch.txt` and target
+	// `config.project.canonicalBranch` directly. A stale session branch (e.g.
+	// operator's leftover docs branch) would otherwise silently capture mission
+	// merges, producing pr-phase PRs with the wrong diff. Operators running
+	// `ha merge` interactively keep the existing sessionBranch behavior; an
+	// explicit `--into` still wins in both contexts.
+	const inMissionContext =
+		into === undefined &&
+		typeof process.env.HARU_MISSION_TASK_ID === "string" &&
+		process.env.HARU_MISSION_TASK_ID.length > 0;
 	let sessionBranch: string | null = null;
-	if (into === undefined) {
+	if (into === undefined && !inMissionContext) {
 		const sessionBranchPath = join(
 			config.project.root,
 			detectHaruDir(config.project.root),

--- a/src/missions/cells/pr-phase.test.ts
+++ b/src/missions/cells/pr-phase.test.ts
@@ -1921,3 +1921,159 @@ describe("prPhaseCell create — push before gh pr create", () => {
 		expect(result.trigger).toBe("pr_created");
 	});
 });
+
+// =============================================================================
+// #462: pr-phase trusts featureBranch tree when local main is stale
+// =============================================================================
+
+/**
+ * Build a fake spawn that returns differentiated stdout per git ref. Each
+ * rev-parse call replies with the value the test supplies for that ref. All
+ * other commands (fetch, commit-tree, update-ref, push) succeed with empty
+ * stdout. commit-tree returns a fixed SHA so the create handler proceeds.
+ */
+function makeRefAwareSpawn(refToOid: Record<string, string>): typeof Bun.spawn {
+	const stream = (text: string): ReadableStream =>
+		new ReadableStream({
+			start(c) {
+				c.enqueue(new TextEncoder().encode(text));
+				c.close();
+			},
+		});
+	return ((args: readonly string[]) => {
+		if (args[0] === "git" && args[1] === "rev-parse" && typeof args[2] === "string") {
+			const ref = args[2];
+			const oid = refToOid[ref];
+			if (oid === undefined) {
+				return {
+					exited: Promise.resolve(1),
+					stdout: null,
+					stderr: null,
+					unref: () => {},
+				} as unknown as ReturnType<typeof Bun.spawn>;
+			}
+			return {
+				exited: Promise.resolve(0),
+				stdout: stream(`${oid}\n`),
+				stderr: null,
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}
+		if (args[0] === "git" && args[1] === "commit-tree") {
+			return {
+				exited: Promise.resolve(0),
+				stdout: stream("new-commit-sha\n"),
+				stderr: null,
+				unref: () => {},
+			} as unknown as ReturnType<typeof Bun.spawn>;
+		}
+		return {
+			exited: Promise.resolve(0),
+			stdout: null,
+			stderr: null,
+			unref: () => {},
+		} as unknown as ReturnType<typeof Bun.spawn>;
+	}) as unknown as typeof Bun.spawn;
+}
+
+describe("prPhaseCell create — #462 trust feature-branch tree when local main is stale", () => {
+	let savedBudget: GhBudget | null;
+
+	beforeEach(() => {
+		savedBudget = null;
+		try {
+			savedBudget = getGhBudget();
+		} catch {
+			savedBudget = null;
+		}
+	});
+
+	afterEach(() => {
+		setGhBudget(savedBudget);
+	});
+
+	test("#462-A: feature-branch tree differs from BOTH origin/main and stale local main → uses feature tree, pr_created", async () => {
+		// Smoking-gun scenario: mission output committed to featureBranch only,
+		// local main never received the merge (stuck on pre-mission state).
+		const refToOid: Record<string, string> = {
+			"origin/main": "origin-main-sha",
+			"origin-main-sha^{tree}": "origin-main-tree",
+			"refs/heads/feature/x": "feature-sha",
+			"refs/heads/feature/x^{tree}": "feature-tree",
+			main: "stale-main-sha",
+			"stale-main-sha^{tree}": "origin-main-tree", // local main = stale (same tree as origin/main)
+		};
+		const fakeSpawn = makeRefAwareSpawn(refToOid);
+
+		const commitTreeBox: { value: string | null } = { value: null };
+		const wrappedSpawn = ((args: readonly string[], opts?: unknown) => {
+			if (args[0] === "git" && args[1] === "commit-tree" && typeof args[2] === "string") {
+				commitTreeBox.value = args[2];
+			}
+			return (fakeSpawn as unknown as (a: readonly string[], o?: unknown) => unknown)(
+				args,
+				opts,
+			) as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+
+		const { budget } = makeFakeGhBudget(({ args }) => {
+			if (args[0] === "pr" && args[1] === "create") {
+				return { exitCode: 0, stdout: "https://github.com/x/y/pull/462" };
+			}
+			return { exitCode: 0 };
+		});
+		setGhBudget(budget);
+
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: wrappedSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+
+		expect(result.trigger).toBe("pr_created");
+		// The commit synthesized for the PR MUST use the feature-branch tree
+		// (where the real mission output lives), NOT the stale main tree.
+		expect(commitTreeBox.value).toBe("feature-tree");
+	});
+
+	test("#462-B (no-regression): feature tree absent → falls back to local main tree", async () => {
+		// Pre-#462 baseline behavior: when the mission committed to main (e.g.
+		// `ha merge` already ran into main as expected), feature-branch ref may
+		// not exist locally yet. The handler must still use main^{tree}.
+		const refToOid: Record<string, string> = {
+			"origin/main": "origin-main-sha",
+			"origin-main-sha^{tree}": "origin-main-tree",
+			main: "local-main-sha",
+			"local-main-sha^{tree}": "local-main-tree",
+			// refs/heads/feature/x intentionally absent
+		};
+		const fakeSpawn = makeRefAwareSpawn(refToOid);
+
+		const commitTreeBox: { value: string | null } = { value: null };
+		const wrappedSpawn = ((args: readonly string[], opts?: unknown) => {
+			if (args[0] === "git" && args[1] === "commit-tree" && typeof args[2] === "string") {
+				commitTreeBox.value = args[2];
+			}
+			return (fakeSpawn as unknown as (a: readonly string[], o?: unknown) => unknown)(
+				args,
+				opts,
+			) as ReturnType<typeof Bun.spawn>;
+		}) as unknown as typeof Bun.spawn;
+
+		const { budget } = makeFakeGhBudget(({ args }) => {
+			if (args[0] === "pr" && args[1] === "create") {
+				return { exitCode: 0, stdout: "https://github.com/x/y/pull/2" };
+			}
+			return { exitCode: 0 };
+		});
+		setGhBudget(budget);
+
+		const handlers = prPhaseCell.buildHandlers(makeBaseDeps({ spawn: wrappedSpawn }));
+		const result = await handlers.create!(
+			makeCtx({ mission: makeMission({ featureBranch: "feature/x" }) as unknown as Mission }),
+		);
+
+		expect(result.trigger).toBe("pr_created");
+		// Falls back to local main tree (existing behavior).
+		expect(commitTreeBox.value).toBe("local-main-tree");
+	});
+});

--- a/src/missions/cells/pr-phase.ts
+++ b/src/missions/cells/pr-phase.ts
@@ -242,10 +242,35 @@ function buildHandlers(deps: PhaseCellDeps, config?: PhaseCellConfig): HandlerRe
 				return out.length > 0 ? out : null;
 			};
 
-			const tree = await readRef("main^{tree}");
+			// Bug fix #462: when local `main` is stale relative to origin/main
+			// (e.g. operator's `ha merge` redirected mission commits into a
+			// stale `session-branch.txt` target instead of main), reading
+			// `main^{tree}` produces the PRE-mission tree and the resulting PR
+			// reverts whatever was squash-merged from origin since. Prefer the
+			// mission's featureBranch tree when it exists and is ahead of
+			// origin/main — that ref holds the real mission output even when it
+			// never reached main.
 			const parent = await readRef("origin/main");
-			const parentTree = parent ? await readRef(`${parent}^{tree}`) : null;
-			if (!tree || !parent) {
+			if (!parent) {
+				return { trigger: "pr_create_network_fail" };
+			}
+			const featureRef = `refs/heads/${featureBranch}`;
+			const featureTree = (await readRef(featureRef))
+				? await readRef(`${featureRef}^{tree}`)
+				: null;
+			const mainCommit = await readRef("main");
+			const mainTree = mainCommit ? await readRef(`${mainCommit}^{tree}`) : null;
+			const parentTree = await readRef(`${parent}^{tree}`);
+
+			// Prefer feature-branch tree when it differs from BOTH origin/main
+			// and from local main — that's the smoking-gun signal the mission
+			// committed to its branch but the local main view is stale.
+			let tree: string | null = mainTree;
+			if (featureTree && featureTree !== parentTree && featureTree !== mainTree) {
+				tree = featureTree;
+			}
+
+			if (!tree) {
 				return { trigger: "pr_create_network_fail" };
 			}
 			if (parentTree === tree) {


### PR DESCRIPTION
Closes #462.

## Problem

PR #460 published a wrong-diff PR that reverted an unrelated already-merged change. Two-stage root cause:

1. \`ha merge\` without \`--into\` fell through to \`session-branch.txt\`, which held a stale operator branch (\`fix/readme-footer-symmetry\`). Mission builder commits merged into that branch instead of \`main\`.
2. \`pr-phase.ts:245\` then read \`main^{tree}\` as ground truth — but local \`main\` was stale (the work landed on the operator branch), so the synthesized PR commit carried the pre-mission tree and reverted anything squash-merged on origin since.

## Approach C — root cause + defensive

- **\`src/commands/merge.ts\`** — when \`HARU_MISSION_TASK_ID\` is set (mission context from spawn env), bypass \`session-branch.txt\` and target \`config.project.canonicalBranch\` directly. Operators running \`ha merge\` interactively keep existing sessionBranch behavior; \`--into\` still wins.
- **\`src/missions/cells/pr-phase.ts\`** — prefer the mission's \`featureBranch\` tree when it differs from both \`origin/main\` and local \`main\`. Catches the case where operator state has already drifted (defense in depth). Falls back to local main when featureBranch ref is absent.

## Files changed

| File | + | − |
|---|---|---|
| \`src/commands/merge.ts\` | 16 | 0 |
| \`src/missions/cells/pr-phase.ts\` | 31 | 0 |
| \`src/commands/merge.test.ts\` | 56 | 0 |
| \`src/missions/cells/pr-phase.test.ts\` | 156 | 0 |

## Tests

- \`merge.test.ts\` — new test verifies HARU_MISSION_TASK_ID bypasses stale \`session-branch.txt\` and lands on canonicalBranch. 33 pass, 0 fail.
- \`pr-phase.test.ts\` — 2 new tests: featureBranch tree preferred when local main is stale; falls back to main tree when featureBranch ref missing (no-regression). My tests pass; 13 pre-existing failures unchanged.

## Coordination with #461

\`HARU_MISSION_TASK_ID\` was already injected by spawn (\`src/agents/spawn.ts:548\`); this PR reuses that signal. The companion fix #461 / PR #464 adds \`HARU_MISSION_ID\` / \`HARU_MISSION_SLUG\` for branch naming, which is a different code path.